### PR TITLE
FEATURE: REMOVE-CATEGORY [EXPEREM+CLI] optional orphan purge; MATLAB train defaults; MATLAB v2.0 changes implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Activate your virtual environment first (e.g. `source venv/bin/activate` or, in 
 > ./run.sh
 ```
 
-This opens a menu for **Train**, **Plot**, **Predict**, or **Export**, then prompts for every parameter (paths, vigilance, learning rate, resampling, etc.) with defaults and validation. You can also call the CLI directly through the script: `./run.sh train -i ./contours -o results.pkl`.
+This opens a menu for **Train**, **Plot**, **Predict**, or **Export**, then prompts for every parameter (paths, vigilance, learning rate, bias default **1e-6**, resampling default **on** with sample interval **0.01** s, etc.) with defaults aligned to MATLAB **`ARTwarp_cli_mode.m`**. You can also call the CLI directly through the script: `./run.sh train -i ./contours -o results.pkl`.
 
 Basic commands:
 
@@ -100,19 +100,27 @@ Basic commands:
 > artwarp-py train --input-dir ./contours --output results.pkl --export-refs --export-categories
 ```
 
-Resample with sample interval (seconds) [default = 0.02s]:
-
+Resampling is **on** by default (MATLAB `resample=1`); sample interval defaults to **0.01** s (`sampleInterval` in **`ARTwarp_cli_mode.m`**).
 
 ```bash
-# resample contours to uniform temporal resolution (like MATLAB resample option)
-> artwarp-py train --input-dir ./contours --output results.pkl --resample --sample-interval 0.02
+# same as default train (resample + 0.01 s); explicit flags optional
+> artwarp-py train --input-dir ./contours --output results.pkl --sample-interval 0.01 --tempres 0.01
+# skip resampling (MATLAB resample=0)
+> artwarp-py train --input-dir ./contours --output results.pkl --no-resample
 ```
 
 Altogether (resampling & exporting reference contours / category assignments):
 
 ```bash
 # full command
-> artwarp-py train --input-dir ./contours --output results.pkl --resample --sample-interval 0.02 --vigilance 85 --learning-rate 0.1 --max-iterations 50 --export-refs --export-categories
+> artwarp-py train --input-dir ./contours --output results.pkl --vigilance 85 --learning-rate 0.1 --max-iterations 50 --export-refs --export-categories
+```
+
+Optional training extensions (not in MATLAB `stable`; same behaviour as merged branch `martion2007/delete_unused_categories`):
+
+```bash
+> artwarp-py train --input-dir ./contours --output results.pkl \
+    --deprioritize-lone-category-search --purge-empty-categories
 ```
 
 Generate visualizations:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This directory contains detailed internal documentation for end-users, developer
 ## Contents
 
 ### Test Documentation
-- **docs/dev/TEST_RESULTS.md** - Complete test report with all 164 tests documented
+- **docs/dev/TEST_RESULTS.md** - Complete test report with full test suite documented
   - Test execution results
   - Bug fixes applied during testing
   - Performance benchmarks
@@ -117,7 +117,6 @@ The **GitHub Wiki** for this repo is synced from this `docs/` directory. When yo
 | `docs/dev/ENVIRONMENT_SETUP.md` | Dev-ENVIRONMENT_SETUP |
 | `docs/dev/TEST_RESULTS.md` | Dev-TEST_RESULTS |
 | `docs/dev/PERFORMANCE_OPTIMIZATIONS.md` | Dev-PERFORMANCE_OPTIMIZATIONS |
-
 ---
 
 @author: Pedro Gronda Garrigues

--- a/docs/dev/ENVIRONMENT_SETUP.md
+++ b/docs/dev/ENVIRONMENT_SETUP.md
@@ -296,7 +296,7 @@ OS: Linux 6.18.13-arch1-1
 Python: 3.14.2 (miniconda sig-process)
 Conda: 25.11.0
 Virtual Environment: sig-process (conda)
-Test Results: 183/183 passed (100%) (as of March 2026)
+Test Results: 190/190 passed (100%) (as of April 2026)
 ```
 
 ---

--- a/docs/dev/PROJECT_SUMMARY.md
+++ b/docs/dev/PROJECT_SUMMARY.md
@@ -86,7 +86,7 @@ Status: Fully functional
 
 #### Resampling (`src/artwarp/utils/resample.py`)
 - Resample contours to a uniform temporal resolution (seconds per point)
-- Used by `train --resample` and optionally via `load_contours(..., return_tempres=True)` + `resample_contours()`
+- Used by `train` when resampling is on (default, MATLAB `resample=1`) and via `load_contours(..., return_tempres=True)` + `resample_contours()`
 
 ### 4. Command-Line Interface
 
@@ -103,13 +103,14 @@ Status: Fully functional
 #### Unit Tests
 - **test_dtw.py**: DTW algorithm tests (29 tests: core DTW/unwarp + Python-path tests for coverage when Numba disabled)
 - **test_art.py**: ART component tests (18 tests)
-- **test_network.py**: Network training and prediction tests (24 tests: includes `TestCategoryParentNames` for provenance tracking)
+- **test_network.py**: Network training and prediction tests (26 tests: includes `TestCategoryParentNames` for provenance tracking and optional training flags)
+- **test_weights.py**: Weight matrix helpers (8 tests: average/delete/purge/update)
 - **test_visualization.py**: Plotting and report tests (35 tests: core plots, discovery curve, DTW/ART schematic, diagnostics, reporting)
 - **test_matlab_compat.py**: MATLAB file and behavior compatibility tests (9 tests)
 - **test_loaders.py**: Data loaders and exporters tests -> load_ctr_file (incl. provenance fields), load_csv_file, load_txt_file, load_contours, load_mat_categorization, export_reference_contour_metadata (32 tests)
-- **test_validation.py**: Validation utilities tests — validate_contour, validate_contours, validate_parameters, numba (36 tests)
+- **test_validation.py**: Validation utilities tests — validate_contour, validate_contours, validate_parameters, numba, CLI train MATLAB flags and extension flags (39 tests)
 
-**Total**: **183 tests** covering:
+**Total**: **196 tests** covering:
 - Mathematical correctness
 - Edge cases
 - Error handling
@@ -171,6 +172,7 @@ tests/
 │   ├── test_dtw.py
 │   ├── test_art.py
 │   ├── test_network.py
+│   ├── test_weights.py
 │   ├── test_loaders.py
 │   ├── test_validation.py
 │   ├── test_matlab_compat.py
@@ -178,7 +180,7 @@ tests/
 └── __init__.py
 
 ```
-**183 unit tests** in total (see docs/dev/TEST_RESULTS.md for full breakdown).
+**196 unit tests** in total (see docs/dev/TEST_RESULTS.md for full breakdown).
 
 ### Documentation
 ```
@@ -249,7 +251,7 @@ examples/
 ### ✓ Code Quality
 - [x] Complete type hints
 - [x] Comprehensive docstrings
-- [x] Unit tests (164 test cases; see docs/dev/TEST_RESULTS.md)
+- [x] Unit tests (see docs/dev/TEST_RESULTS.md)
 - [x] Integration tests
 - [x] Code formatting (Black)
 - [x] Linting configuration
@@ -285,7 +287,7 @@ The Python implementation maintains exact mathematical equivalence with the orig
 ## Testing Verification
 
 The implementation includes:
-- **183 unit tests** covering all core functions, I/O loaders/exporters, validation, visualization (including discovery curve and additional algorithm/diagnostics/reporting plots), DTW Python fallback (for coverage), and provenance tracking
+- **196 unit tests** covering all core functions, I/O loaders/exporters, validation (including CLI `--recat-single-categories` / `--compare-warped` and optional `--deprioritize-lone-category-search` / `--purge-empty-categories` parsing), `purge_empty_category_columns` and training with extension flags, visualization (including discovery curve and additional algorithm/diagnostics/reporting plots), DTW Python fallback (for coverage), and provenance tracking
 - **test_validation.py** (25 tests): validate_contour, validate_contours, validate_parameters (all branches and error messages)
 - **test_loaders.py** (32 tests): load_ctr_file (incl. provenance fields `id`/`parent_ids`), load_csv_file, load_txt_file, load_contours (formats, return_tempres, errors), load_mat_categorization extended cases, export_reference_contour_metadata (CSV format, UUID generation, one-based option, etc.)
 - **test_dtw.py** (28 tests): core DTW/unwarp plus Python-path tests (NUMBA_AVAILABLE=False) for full coverage of dtw.py fallback

--- a/docs/dev/TEST_RESULTS.md
+++ b/docs/dev/TEST_RESULTS.md
@@ -16,13 +16,13 @@ cachedir: .pytest_cache
 rootdir: /home/pedroggbm/Documents/vp4038-dolphin-acoustics/ARTWarp/artwarp-py
 configfile: pyproject.toml
 plugins: cov-7.0.0
-collected 183 items
-============================= 183 passed in 10.87s =============================
+collected 196 items
+============================= 196 passed in 10.87s =============================
 ```
 
 ### Overall Statistics
-- **Total Tests**: 183
-- **Passed**: 183 (100%)
+- **Total Tests**: 196
+- **Passed**: 196 (100%)
 - **Failed**: 0
 - **Skipped**: 0
 - **Duration**: ~10.9 seconds
@@ -164,7 +164,7 @@ collected 183 items
 ---
 
 ### 5. Network Tests (`test_network.py`)
-**Status**: 24/24 passed
+**Status**: 26/26 passed
 
 #### Initialization (6 tests)
 - `test_default_initialization` - Default parameter values
@@ -174,7 +174,7 @@ collected 183 items
 - `test_invalid_bias` - Bias validation
 - `test_random_seed_reproducibility` - Reproducible results
 
-#### Training (7 tests)
+#### Training (9 tests)
 - `test_simple_training` - Basic training workflow
 - `test_identical_contours_one_category` - Single category formation
 - `test_max_categories_limit` - Maximum category enforcement
@@ -182,6 +182,8 @@ collected 183 items
 - `test_empty_contours_list` - Empty input handling
 - `test_contour_names` - Contour name tracking
 - `test_training_results_structure` - Results structure correctness
+- `test_pr10_flags_training_smoke` - Marco's additional feature flags (`deprioritize_lone_category_search`, `purge_empty_categories`) complete `fit()` without error
+- `test_purge_empty_verbose_shows_purged_count` - Verbose iteration line includes `purged` when purge flag is on
 
 #### Prediction (3 tests)
 - `test_predict_after_training` - Post-training prediction
@@ -202,8 +204,15 @@ collected 183 items
 
 ---
 
+### 5b. Weight matrix (`test_weights.py`)
+**Status**: 8/8 passed
+
+(Average weights MATLAB parity, delete/reindex, optional **`purge_empty_category_columns`** for Marco's orphan purge feature, `update_weights` compare-warped branch.)
+
+---
+
 ### 6. Validation and Utils Tests (`test_validation.py`)
-**Status**: 36/36 passed
+**Status**: 39/39 passed (includes `TestCLITrainMatlabFlags`: CLI `--recat-single-categories` / `--compare-warped` / flags argparse)
 
 #### Validate Contour (8 tests)
 - `test_valid_contour_passes` - Valid 1D positive numeric array
@@ -440,7 +449,7 @@ isort==7.0.0
 
 ## Conclusion
 
-**ARTwarp-py v1.0.1 passes all 183 tests with 100% success rate.**
+**ARTwarp-py v1.0.1 passes all 196 tests with 100% success rate.**
 
 ## Author Note
 
@@ -455,7 +464,7 @@ Thank you.
 ---
 
 _Test execution completed: March, 2026_  
-_All tests passed: 183/183 (100%)_  
+_All tests passed: 196/196 (100%)_  
 _Status: READY FOR USE_
 
 ---

--- a/docs/user/API.md
+++ b/docs/user/API.md
@@ -17,7 +17,11 @@ network = ARTwarp(
     max_iterations=50,
     warp_factor_level=3,
     random_seed=None,
-    verbose=True
+    verbose=True,
+    recat_single_categories=False,
+    compare_warped=False,
+    deprioritize_lone_category_search=False,
+    purge_empty_categories=False,
 )
 ```
 
@@ -33,7 +37,7 @@ network = ARTwarp(
   
 - **bias** (float, default=0.0): Activation bias, range [0, 1]
   - Higher bias makes categories more selective
-  - Usually kept at 0.0 for standard ARTwarp
+  - Default **0.0** matches typical MATLAB **GUI** usage. The **`train`** CLI uses **`--bias`** default **1e-6** (MATLAB **`ARTwarp_cli_mode.m`**).
   
 - **max_categories** (int, default=100): Maximum number of categories to create
   - Prevents unlimited category growth
@@ -54,6 +58,14 @@ network = ARTwarp(
   - Leave None for different results each run
   
 - **verbose** (bool, default=True): Whether to print progress information
+
+- **recat_single_categories** (bool, default=False): If True, after each training iteration’s sample loop, run the same post-pass as MATLAB `ARTwarp_Recat_Single_Cats` (GUI/CLI `recatSingleCats`). Lone-category contours may be reassigned and empty categories removed via `ARTwarp_Delete_Category`. Default False matches MATLAB with this option off.
+
+- **compare_warped** (bool, default=False): If True, use MATLAB `compareWarped == 1` weight updates (`ART_Update_Weights` / `ARTwarp_Update_Weights`) and, after each iteration, `ARTwarp_Average_Weights`. Default False matches MATLAB with this option off.
+
+- **deprioritize_lone_category_search** (bool, default=False): **Not in MATLAB `stable`.** When True, if the current sample is the **only** contour assigned to its category, the resonance search tries **other** categories (by activation order) **before** its current category—matching experimental PR (`martion2007/delete_unused_categories`). CLI: **`--deprioritize-lone-category-search`**.
+
+- **purge_empty_categories** (bool, default=False): **Not in MATLAB `stable`.** When True, after each iteration (after optional `recat_single_categories` and `compare_warped`), remove weight columns with **zero** assigned contours and reindex category indices (`purge_empty_category_columns` in `weights.py`). This is **orphan-column cleanup**, distinct from MATLAB’s lone-contour recat (which deletes a column only after a **successful** reassignment). Verbose training prints **`purged N empty categories`** each iteration when this flag is on. CLI: **`--purge-empty-categories`**.
 
 #### Methods
 
@@ -347,7 +359,7 @@ Ensure the `artwarp-py` command is on your PATH (activate your virtual environme
 
 ### train
 
-Train a network on contour files. Parameters that affect the **ARTwarp network** (vigilance, learning_rate, bias, max_categories, max_iterations, warp_factor_level, random_seed, verbose) are passed into the `ARTwarp` constructor. The options **resample**, **sample-interval**, and **tempres** are **preprocessing** only: they resample contours before training and are not network parameters.
+Train a network on contour files. Parameters that affect the **ARTwarp network** (vigilance, learning_rate, bias, max_categories, max_iterations, warp_factor_level, random_seed, verbose, recat_single_categories, compare_warped, deprioritize_lone_category_search, purge_empty_categories) are passed into the `ARTwarp` constructor. **Preprocessing:** by default, contours are **resampled** like MATLAB **`ARTwarp_cli_mode.m`** (`resample=1`, `sampleInterval=0.01`); pass **`--no-resample`** to match `resample=0`. **`--tempres`** only applies when resampling is on. The Python class `ARTwarp(..., bias=0.0)` still defaults bias to zero for direct API use; **`train`** passes **`--bias`** (default **1e-6**) into the constructor so CLI matches MATLAB CLI.
 
 If you wish to preprocess in a separate Python script, call the functions listed in the example code cells above.
 
@@ -361,17 +373,21 @@ If you wish to preprocess in a separate Python script, call the functions listed
 | `--freq-column` | 0 | Frequency column index (CSV/TXT) |
 | `--vigilance` | 85.0 | Match threshold [1, 99] → `ARTwarp(vigilance=...)` |
 | `--learning-rate` | 0.1 | Weight update rate → `ARTwarp(learning_rate=...)` |
-| `--bias` | 0.0 | Activation bias → `ARTwarp(bias=...)` |
+| `--bias` | 1e-6 | Activation bias → `ARTwarp(bias=...)` (MATLAB `ARTwarp_cli_mode` default) |
 | `--max-categories` | 50 | Max categories → `ARTwarp(max_categories=...)` |
 | `--max-iterations` | 50 | Max iterations → `ARTwarp(max_iterations=...)` |
 | `--warp-factor` | 3 | DTW warping factor → `ARTwarp(warp_factor_level=...)` |
 | `--seed` | None | Random seed → `ARTwarp(random_seed=...)` |
+| `--recat-single-categories` | false | MATLAB `recatSingleCats` → `ARTwarp(recat_single_categories=True)` |
+| `--compare-warped` | false | MATLAB `compareWarped` → `ARTwarp(compare_warped=True)` |
+| `--deprioritize-lone-category-search` | false | Non-MATLAB PR: lone-category search order → `ARTwarp(deprioritize_lone_category_search=True)` |
+| `--purge-empty-categories` | false | Non-MATLAB PR: drop orphan prototype columns each iter → `ARTwarp(purge_empty_categories=True)` |
 | `--export-refs` | false | Export reference contours to CSV and provenance `metadata.csv` |
 | `--export-categories` | false | Export category assignments to CSV |
 | `-q`, `--quiet` | false | Suppress progress → `ARTwarp(verbose=False)` |
-| `--resample` | false | **Preprocessing**: resample contours to uniform temporal resolution before training |
-| `--sample-interval` | 0.02 | **Preprocessing**: target sampling interval (seconds) when `--resample` |
-| `--tempres` | 0.01 | **Preprocessing**: default temporal resolution (sec/point) for contours without it, when `--resample` |
+| `--resample` / `--no-resample` | resample **on** | **Preprocessing**: resample before training (MATLAB `resample=1`); use `--no-resample` for `resample=0` |
+| `--sample-interval` | 0.01 | **Preprocessing**: target sampling interval in seconds (MATLAB `sampleInterval`) |
+| `--tempres` | 0.01 | **Preprocessing**: default sec/point when a contour has no tempres, when resampling is on |
 
 **Example (basic)**:
 
@@ -389,13 +405,33 @@ artwarp-py train \
     --export-categories
 ```
 
-**Example (with resampling, MATLAB-aligned)**:
+**Example (explicit resample interval / tempres; resampling is already on by default)**:
 
 ```bash
-artwarp-py train -i ./contours -o results.pkl --resample --sample-interval 0.02 --tempres 0.01
+artwarp-py train -i ./contours -o results.pkl --sample-interval 0.01 --tempres 0.01
 ```
 
-When `--resample` is used, contours are loaded with `return_tempres=True`, then `resample_contours(contours, tempres_list, sample_interval)` is called; contours without tempres use `--tempres`. The resampled contours are then passed to `ARTwarp(...).fit(contours, names)`.
+**Example (skip resampling, MATLAB `resample=0`)**:
+
+```bash
+artwarp-py train -i ./contours -o results.pkl --no-resample
+```
+
+**Example (MATLAB optional training flags, same order of effect as `ARTwarp_Run_Categorisation.m`)**:
+
+```bash
+artwarp-py train -i ./contours -o results.pkl --recat-single-categories --compare-warped
+```
+
+**Example (optional Marco's extensions — not in MATLAB `stable`)**:
+
+```bash
+artwarp-py train -i ./contours -o results.pkl \
+  --deprioritize-lone-category-search \
+  --purge-empty-categories
+```
+
+With default resampling **on**, contours are loaded with `return_tempres=True`, then `resample_contours(contours, tempres_list, sample_interval)` is called; contours without tempres use `--tempres`. Use **`--no-resample`** to skip. The **`train`** command passes **`--bias`** (default **1e-6**) into `ARTwarp` unless you override it.
 
 ### predict
 

--- a/docs/user/ARCHITECTURE.md
+++ b/docs/user/ARCHITECTURE.md
@@ -113,12 +113,14 @@ Done          Try Next Category
 - `update_weights()`: Apply learning rule with length adaptation
 - `get_weight_contour()`: Extract category prototype
 
-**Weight Update Algorithm**:
+**Weight Update Algorithm** (when `compare_warped` is False, matching MATLAB `compareWarped == 0`):
 1. Warp input to match weight length using DTW result
 2. Update content: `new_weight = old_weight + lr * (warped_input - old_weight)`
 3. Calculate new length: `new_length = old_length + lr * (input_length - old_length)`
 4. Unwarp and interpolate to new length
 5. Store in weight matrix
+
+When `compare_warped` is True (MATLAB `compareWarped == 1`), the implementation follows `ART_Update_Weights.m`: fixed reference length (no unwarp pass) and content update from the warped input as in MATLAB.
 
 ### 4. Main Network (`core/network.py`)
 
@@ -136,8 +138,12 @@ Constructor parameters (all passed from CLI `train` where applicable):
 - `warp_factor_level` (int, default 3): DTW warping factor (CLI `--warp-factor`)
 - `random_seed` (int, optional): Reproducibility (CLI `--seed`)
 - `verbose` (bool, default True): Progress output (CLI `-q`/`--quiet` inverts)
+- `recat_single_categories` (bool, default False): MATLAB `recatSingleCats` (CLI `--recat-single-categories`)
+- `compare_warped` (bool, default False): MATLAB `compareWarped` (CLI `--compare-warped`)
+- `deprioritize_lone_category_search` (bool, default False): **Not in MATLAB `stable`.** Optional search-order tweak from merged experimental PR (`martion2007/delete_unused_categories`): when a sample is the only contour in its category, try other categories before its current one in the resonance loop (CLI `--deprioritize-lone-category-search`).
+- `purge_empty_categories` (bool, default False): **Not in MATLAB `stable`.** Optional post-iteration cleanup from the same PR: remove weight columns with **zero** assigned contours and reindex labels (CLI `--purge-empty-categories`). Distinct from MATLAB’s **`ARTwarp_Recat_Single_Cats`** (Kai / `recatSingleCats`), which only removes a column after a **successful** lone-contour reassignment.
 
-Resampling is **not** a network parameter: `--resample`, `--sample-interval`, and `--tempres` are applied in the CLI by loading contours with `return_tempres=True`, calling `resample_contours(contours, tempres_list, sample_interval)`, then passing the resampled contours to `ARTwarp(...).fit(contours, names)`.
+Resampling is **not** a network parameter: the **`train`** CLI applies resampling by default (MATLAB `resample=1`); `--no-resample` turns it off. With resampling on, the CLI loads contours with `return_tempres=True`, calls `resample_contours(contours, tempres_list, sample_interval)`, then passes contours to `ARTwarp(...).fit(contours, names)`.
 
 - Implements training loop
 - Handles convergence detection
@@ -206,7 +212,7 @@ for iteration in range(max_iterations):
 **Key Function**: `resample_contours(contours, tempres, sample_interval_sec)`  
 Matches MATLAB ARTwarp "Resample Contours" option: same formula as `interp1(1:length(contour), contour, 1:sampleInterval/tempres:length(contour))`. Use before `fit()` when contours have different sampling rates.
 
-**CLI** (`train` command): `--resample` enables resampling before training. `--sample-interval SEC` (default 0.02) is the target sampling interval in seconds. `--tempres SEC` (default 0.01) is the default temporal resolution (seconds per point) for contours that do not provide it (e.g. some .ctr files). When `--resample` is set, contours are loaded with `return_tempres=True`, missing tempres are filled with `--tempres`, then `resample_contours(contours, tempres_list, sample_interval)` is called; the resampled contours are passed to `ARTwarp(...).fit(contours, names)`. These options are not passed into the ARTwarp constructor.
+**CLI** (`train` command): resampling is **on by default** (`--no-resample` to match MATLAB `resample=0`). `--sample-interval SEC` defaults to **0.01** (MATLAB `sampleInterval`). `--tempres SEC` (default 0.01) fills missing per-contour temporal resolution when resampling. These options are preprocessing only, not `ARTwarp` constructor fields.
 
 ### 8. Numba check (`utils/numba_check.py`)
 
@@ -215,6 +221,12 @@ Matches MATLAB ARTwarp "Resample Contours" option: same formula as `interp1(1:le
 **Key functions**: `numba_available()`, `report_numba_status()` (status only), `check_numba(offer_install=True)` (status + optional install prompt). The package calls `report_numba_status()` on import so API users (e.g. in Jupyter) see the Numba status. The CLI calls `check_numba(offer_install=stdin.isatty())` at startup so interactive runs can prompt to install Numba if missing.
 
 **Entry points**: `run.sh` (interactive launcher) and `artwarp-py` / `python -m artwarp.cli.main` (CLI) both trigger the Numba check when run; see **Quick Start** in the main README.
+
+## Tracking MATLAB `stable` v2.0 [NEW]
+
+The reference MATLAB implementation is the sibling directory **`../artwarp`** tracked on branch **`stable`**. Keep that checkout **up to date** (`git pull` there) when you need the latest upstream behaviour; artwarp-py does not auto-sync to remote. Training behaviour in artwarp-py is implemented to match **`ARTwarp_Run_Categorisation.m`**, **`ARTwarp_cli_mode.m`** (CLI defaults), **`ARTwarp_Update_Weights.m`**, **`ARTwarp_Recat_Single_Cats.m`**, **`ARTwarp_Average_Weights.m`**, and related `.m` files as they exist on **`stable`** at your pulled revision.
+
+**Not identical run-for-run to MATLAB:** sample order uses different RNG (`sort(randn(n,1))` vs NumPy). The **`ARTwarp`** Python class still defaults **`bias=0.0`** (typical GUI); the **`train`** CLI defaults **`bias=1e-6`** and **resampling on**, matching **`ARTwarp_cli_mode.m`**.
 
 ## Alignment with MATLAB ARTwarp
 
@@ -228,10 +240,12 @@ This implementation is a rewrite of [artwarp](https://github.com/dolphin-acousti
 | **Valid weight positions** | `find(weight > 0)` for activation, match, update | `(weight > 0) & np.isfinite(weight)` in art.py and weights.py |
 | **DTW length ratio** | Reject when `max(m,n)/(min(m,n)-1) >= warpFactorLevel` | Same; check runs first (before short-contour branch) |
 | **Load saved run** | "Load Categorization" (.mat with NET, DATA) | `load_mat_categorization(filepath)` in `artwarp.io.loaders` |
-| **Resample option** | GUI: resample to sampleInterval (ms) using tempres | `resample_contours(contours, tempres, sample_interval_sec)` in `artwarp.utils`; CLI: `--resample --sample-interval 0.02 --tempres 0.01` |
+| **Resample option** | GUI / CLI `ARTwarp_cli_mode`: resample default **on**, `sampleInterval` default **0.01** s | `resample_contours(...)` in `artwarp.utils`; CLI defaults resample **on** (`--no-resample` to disable), `--sample-interval` default **0.01**, `--tempres` default **0.01** |
+| **recatSingleCats** | Optional after each iteration: `ARTwarp_Recat_Single_Cats.m` | `recat_single_categories=True` or CLI `--recat-single-categories` (default off, same as MATLAB unchecked) |
+| **compareWarped** | Optional: `compareWarped` in `ARTwarp_Update_Weights`; then `ARTwarp_Average_Weights.m` each iteration | `compare_warped=True` or CLI `--compare-warped` (default off) |
 | **.ctr / .csv / .txt** | Load_Data, Load_CSV_Data, Load_TabDelim_Data | `load_contours(..., file_format='ctr'|'csv'|'txt')`, same contour and tempres; optional `return_tempres=True` for resampling |
 
-Algorithm steps (warp, unwarp, activate, match, update_weights, add_new_category, training loop and convergence) match the MATLAB logic.
+Algorithm steps (warp, unwarp, activate, match, update_weights, add_new_category, training loop and convergence) match the MATLAB logic. Optional post-iteration passes (`recatSingleCats`, `compareWarped`) match `ARTwarp_Run_Categorisation.m` order: inner sample loop, then recat if enabled, then average weights if `compareWarped`, then (if enabled) `purge_empty_categories` via `purge_empty_category_columns()` in `weights.py`, then convergence on inner-loop reclassifications only. The in-loop **`deprioritize_lone_category_search`** step runs only when that flag is on (non-MATLAB).
 
 ### Feature parity with MATLAB artwarp
 
@@ -239,12 +253,17 @@ Algorithm steps (warp, unwarp, activate, match, update_weights, add_new_category
 |--------|--------|--------|
 | warp.m, unwarp.m | core/dtw.py | Same algorithm, length ratio and constraints aligned |
 | ARTwarp_Calculate_Match, _Activate_Categories, _Add_New_Category, _Update_Weights | core/art.py, core/weights.py | Same logic; valid = weight > 0 |
-| ARTwarp_Run_Categorization | core/network.py `fit()` | Same loop, convergence, resample option via `resample_contours()` |
+| ARTwarp_Run_Categorisation | core/network.py `fit()` | Same loop and convergence; optional `ARTwarp_Recat_Single_Cats` / `ARTwarp_Average_Weights` when flags set; resample via `resample_contours()` before `fit()` |
+| ARTwarp_Recat_Single_Cats | `_recat_single_categories()` | When `recat_single_categories` / `--recat-single-categories` |
+| ARTwarp_Average_Weights | `average_weights()` in weights.py | When `compare_warped` / `--compare-warped` (after recat block in MATLAB order) |
+| *(none on MATLAB `stable`)* | `purge_empty_category_columns()` in `weights.py` | Optional: `purge_empty_categories` / `--purge-empty-categories` after recat + compare-warped |
+| *(none on MATLAB `stable`)* | `deprioritize_lone_category_search` in `network.py` | Optional: `--deprioritize-lone-category-search` inside sample loop |
+| ARTwarp_Update_Weights (compare_warped) | `update_weights(..., compare_warped=...)` | Matches `ART_Update_Weights.m` branches |
 | Load_Data, Load_CSV_Data, Load_TabDelim_Data | io/loaders.py `load_contours()` | .ctr, .csv, .txt; same contour/tempres handling |
 | SaveRefContours.m | io/exporters.py `export_reference_contours()` | refContour_1.csv, %7.1f |
 | REFCONTOURS struct (id, parent_ids) | `TrainingResults.category_parent_names`; `export_reference_contour_metadata()` | CSV instead of .ctr; UUID per prototype, parent names list |
 | Load Categorization (.mat) | io/loaders.py `load_mat_categorization()` | NET + optional DATA |
-| Resample option (GUI) | utils/resample.py `resample_contours()`; CLI `train --resample` | Same formula; CLI uses `--sample-interval`, `--tempres` |
+| Resample option (GUI / CLI) | utils/resample.py `resample_contours()`; CLI resample **on** by default | Same formula; `--no-resample` disables; `--sample-interval` / `--tempres` match `ARTwarp_cli_mode.m` defaults |
 | Get_Parameters, Create_Figure, Plot_Net, Plot_Net2 | CLI + API + visualization/ | No GUI; params via constructor/CLI; plots via `plot_*` |
 | ARTwarp_Assess_Net | — | Not implemented (species misclassification diagnostic) |
 | ARTwarp_Test_Net (assign best, no vigilance) | `predict()` uses vigilance | Can add `assign_best_only` if needed |

--- a/docs/user/INSTALLATION.md
+++ b/docs/user/INSTALLATION.md
@@ -120,7 +120,7 @@ print(f'Test passed! Created {results.num_categories} category(ies)')
 artwarp-py --help
 ```
 
-For an **interactive menu** (prompts for all options), run from the project root: `./run.sh`. When you run the CLI or `./run.sh`, a **Numba status** line is shown; if Numba is not installed, you’ll see a warning and, in an interactive terminal, an option to install it automatically (pip/conda). When you use the Python API (e.g. `import artwarp`), the package prints a one-line Numba status on import.
+For an **interactive menu** (prompts for all options), run from the project root: `./run.sh`. Train defaults match MATLAB **`ARTwarp_cli_mode.m`** (bias **1e-6**, resample **on**, sample interval **0.01** s); optional **MATLAB parity** prompts (`recatSingleCats`, `compareWarped`) match `ARTwarp_Run_Categorisation.m`. The menu also offers optional prompts (`--deprioritize-lone-category-search`, `--purge-empty-categories`) for the experimental behaviours merged historically, not part of MATLAB `stable` v2.0. When you run the CLI or `./run.sh`, a **Numba status** line is shown; if Numba is not installed, you’ll see a warning and, in an interactive terminal, an option to install it automatically (pip/conda). When you use the Python API (e.g. `import artwarp`), the package prints a one-line Numba status on import.
 
 ## Running Tests
 

--- a/docs/user/QUICK_REFERENCE.md
+++ b/docs/user/QUICK_REFERENCE.md
@@ -30,8 +30,16 @@ Then, for direct commands:
 ```bash
 artwarp-py train --input-dir ./contours --output results.pkl --vigilance 85
 
-# with resampling (like MATLAB resample option)
-artwarp-py train --input-dir ./contours --output results.pkl --resample --sample-interval 0.02
+# resampling is on by default (MATLAB ARTwarp_cli_mode); explicit interval / skip:
+artwarp-py train --input-dir ./contours --output results.pkl --sample-interval 0.01
+artwarp-py train --input-dir ./contours --output results.pkl --no-resample
+
+# optional MATLAB training flags (same names as GUI: recatSingleCats, compareWarped)
+artwarp-py train --input-dir ./contours --output results.pkl --recat-single-categories --compare-warped
+
+# optional extensions (non-MATLAB stable; search reorder + orphan column purge)
+artwarp-py train --input-dir ./contours --output results.pkl \
+  --deprioritize-lone-category-search --purge-empty-categories
 
 # generate visualization report
 artwarp-py plot --results results.pkl --input-dir ./contours --output-dir ./report
@@ -49,8 +57,12 @@ Without activating, use the venv’s Python: `./venv/bin/python -m artwarp.cli.m
 | max_categories | 1+ | 50 | Limit category creation |
 | max_iterations | 1+ | 50 | Max training iterations |
 | warp_factor_level | 2+ | 3 | Max time warping |
+| recat_single_categories | on/off | off | MATLAB `recatSingleCats`: lone-contour recat after each iteration |
+| compare_warped | on/off | off | MATLAB `compareWarped`: warped weight branch + average weights each iteration |
+| deprioritize_lone_category_search | on/off | off | Try other categories before current when sample is alone in its category |
+| purge_empty_categories | on/off | off | Each iteration, delete weight columns with zero assigned contours |
 
-**CLI-only (train)**: `--resample` (flag), `--sample-interval SEC` (default 0.02), `--tempres SEC` (default 0.01) — resample contours to uniform temporal resolution before training (MATLAB resample option).
+**CLI-only (train)**: resample **on** by default (`--no-resample` to match MATLAB `resample=0`); `--sample-interval SEC` (default **0.01**), `--tempres SEC` (default **0.01**). **`--recat-single-categories`** and **`--compare-warped`** mirror MATLAB `ARTwarp_Run_Categorisation.m` optional steps (default off). **`--deprioritize-lone-category-search`** and **`--purge-empty-categories`** are optional behaviours (default off). Interactive `./run.sh` prompts for resampling (default yes), bias (default **1e-6**), MATLAB parity flags, then extensions.
 
 ## Common Use Cases
 
@@ -103,13 +115,15 @@ contours, names, tempres = load_contours('./data', return_tempres=True)
 
 ### Resample Before Training (CLI or API)
 ```bash
-artwarp-py train -i ./contours -o results.pkl --resample --sample-interval 0.02
+artwarp-py train -i ./contours -o results.pkl
+# or custom interval (CLI default sample interval is 0.01 s)
+artwarp-py train -i ./contours -o results.pkl --sample-interval 0.02
 ```
 ```python
 from artwarp.utils import resample_contours
 contours, names, tempres = load_contours('./data', return_tempres=True)
 tempres = [t or 0.01 for t in tempres]
-contours = resample_contours(contours, tempres, 0.02)
+contours = resample_contours(contours, tempres, 0.01)
 results = network.fit(contours, contour_names=names)
 ```
 

--- a/docs/user/VISUALIZATION.md
+++ b/docs/user/VISUALIZATION.md
@@ -4,7 +4,7 @@
 
 ARTwarp-py includes visualization capabilities for analyzing and presenting training results. All visualization functions follow scientific plotting best practices and produce research-style figures (to be validated by actual researchers).
 
-This plotting functionality, specific to CLI, serves as a MATLAB rendering alternative. They are generated using the pickle file generated from training (`train` command in CLI), providing good result encapsulation!
+This plotting functionality, specific to CLI, serves as a MATLAB rendering alternative. They are generated using the pickle file generated from training (`train` command in CLI), providing good result encapsulation! Training-time options such as **`--recat-single-categories`** / **`--compare-warped`** (MATLAB `stable`) or optional flags (`--deprioritize-lone-category-search`, `--purge-empty-categories`) only affect what is stored in that pickle if you used them when training.
 
 ## Features
 

--- a/examples/artwarp_demo.ipynb
+++ b/examples/artwarp_demo.ipynb
@@ -1,1047 +1,1136 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# ARTwarp-py — Demo & Guide\n",
-    "\n",
-    "A complete, runnable introduction to **ARTwarp-py**: load real contour files, train the network, interpret every result, and produce publication-quality* figures.\n",
-    "\n",
-    "**What this notebook covers**\n",
-    "\n",
-    "| Section | Topic |\n",
-    "|---------|-------|\n",
-    "| 1 | Imports & setup |\n",
-    "| 2 | Load real contours from `examples/data/` |\n",
-    "| 3 | Data exploration — length & temporal resolution |\n",
-    "| 4 | (Optional) Resampling to a common temporal resolution |\n",
-    "| 5 | Train the ARTwarp network |\n",
-    "| 6 | Inspect training results |\n",
-    "| 7 | Standard result visualizations |\n",
-    "| 8 | Algorithm diagrams |\n",
-    "| 9 | Diagnostic visualizations |\n",
-    "| 10 | Data-quality visualizations |\n",
-    "| 11 | Parameter-study visualizations |\n",
-    "| 12 | Publication figure |\n",
-    "| 13 | Ground-truth evaluation (confusion matrix, label map) |\n",
-    "| 14 | Full automated report |\n",
-    "| 15 | Predict on new contours |\n",
-    "| 16 | Export results |\n",
-    "| 17 | CLI quick reference |\n",
-    "\n",
-    "> **Docs:** `docs/user/API.md` · `docs/user/QUICK_REFERENCE.md` · `docs/user/VISUALIZATION.md`\n",
-    "\n",
-    "*Always double check figure for DPI, dimension, etc, before publication.\n",
-    "\n",
-    "@author: Pedro Gronda Garrigues"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 1  ·  Imports & setup\n",
-    "\n",
-    "Install the package once from the project root: `pip install -e .`  \n",
-    "All cells below require only `artwarp`, `numpy`, and `matplotlib`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "import matplotlib\n",
-    "matplotlib.rcParams['figure.dpi'] = 110\n",
-    "\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# core API\n",
-    "from artwarp import ARTwarp, load_contours\n",
-    "from artwarp.utils import resample_contours\n",
-    "from artwarp.io.exporters import (\n",
-    "    export_results,\n",
-    "    export_reference_contours,\n",
-    "    export_category_assignments,\n",
-    ")\n",
-    "\n",
-    "# all visualization functions\n",
-    "from artwarp.visualization import (\n",
-    "    create_paper_figure,\n",
-    "    create_results_report,\n",
-    "    plot_art_schematic,\n",
-    "    plot_category_distribution,\n",
-    "    plot_category_embedding,\n",
-    "    plot_category_similarity_matrix,\n",
-    "    plot_category_dendrogram,\n",
-    "    plot_confusion_matrix,\n",
-    "    plot_contour_length_distribution,\n",
-    "    plot_contours_by_category,\n",
-    "    plot_convergence_history,\n",
-    "    plot_discovery_curve,\n",
-    "    plot_dtw_alignment,\n",
-    "    plot_label_vs_category,\n",
-    "    plot_match_distribution,\n",
-    "    plot_per_category_match_quality,\n",
-    "    plot_reference_contours,\n",
-    "    plot_resampling_before_after,\n",
-    "    plot_run_stability,\n",
-    "    plot_training_summary,\n",
-    "    plot_vigilance_sweep,\n",
-    "    plot_warp_constraint,\n",
-    ")\n",
-    "\n",
-    "import artwarp\n",
-    "print(f\"artwarp-py  version: {artwarp.__version__}\")\n",
-    "print(f\"numpy       version: {np.__version__}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 2  ·  Load real contours from `examples/data/`\n",
-    "\n",
-    "The `data/` directory contains five dolphin-whistle contour CSV files (columns: `Time [ms]`, `Peak Frequency [Hz]`). These were kindly provided by @Kai Kerlaff, and are in the latest release of ARTwarp (MATLAB version).\n",
-    " \n",
-    "`load_contours` auto-detects the frequency and time columns.  \n",
-    "Passing `return_tempres=True` also returns the per-file temporal resolution inferred from the time column."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DATA_DIR = Path(\"../contours-sarasota\")   # relative to examples/\n",
-    "# DATA_DIR = Path(\"../contours\")\n",
-    "\n",
-    "contours, names, tempres_list = load_contours(\n",
-    "    str(DATA_DIR),\n",
-    "    file_format=\"auto\",\n",
-    "    return_tempres=True,\n",
-    ")\n",
-    "\n",
-    "print(f\"Loaded {len(contours)} contours\")\n",
-    "for name, ctr, tr in zip(names, contours, tempres_list):\n",
-    "    print(f\"  {name:20s}  length={len(ctr):4d} pts   tempres={tr:.4f} s/pt   \"\n",
-    "          f\"duration={len(ctr)*tr*1000:.1f} ms   \"\n",
-    "          f\"freq=[{ctr.min():.0f}, {ctr.max():.0f}] Hz\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 3  ·  Data exploration — length & temporal resolution\n",
-    "\n",
-    "Before training it is good practice to understand your dataset's shape.  \n",
-    "`plot_contour_length_distribution` gives you histograms of both contour length (in samples) and temporal resolution (seconds per sample) in one figure.\n",
-    "\n",
-    "Contours with very different temporal resolutions should be resampled to a common interval before training (see Section 4)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_contour_length_distribution(\n",
-    "    contours,\n",
-    "    tempres_list=tempres_list,\n",
-    "    figsize=(13, 5),\n",
-    ")\n",
-    "plt.show()\n",
-    "\n",
-    "# TODO: fix temporal resolution distribution plot"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 4  ·  (Optional) Resampling to a common temporal resolution\n",
-    "\n",
-    "If your files have different temporal resolutions (e.g., 5 ms vs 10 ms per sample), DTW comparisons can be misleading because one contour appears longer than it physically is.  \n",
-    "Resampling interpolates every contour to the same time step.\n",
-    "\n",
-    "`plot_resampling_before_after` shows the effect on a single contour so you can sanity-check the result."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# SAMPLE_INTERVAL = 0.005  # 5 ms per sample -> keeps original resolution for this dataset\n",
-    "SAMPLE_INTERVAL = 0.010\n",
-    "\n",
-    "# visualise what resampling to 10 ms would look like on the first contour\n",
-    "fig = plot_resampling_before_after(\n",
-    "    contours[0],\n",
-    "    tempres=tempres_list[0],\n",
-    "    sample_interval_sec=0.010,\n",
-    "    title=f\"resampling demo — {names[0]}\",\n",
-    "    figsize=(12, 5),\n",
-    ")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# apply resampling (resample to 5 ms to normalise any small differences)\n",
-    "contours_resampled = resample_contours(contours, tempres_list, SAMPLE_INTERVAL)\n",
-    "\n",
-    "print(\"Contour lengths before and after resampling:\")\n",
-    "for name, orig, resampled in zip(names, contours, contours_resampled):\n",
-    "    print(f\"  {name:20s}  {len(orig):4d} → {len(resampled):4d} pts\")\n",
-    "\n",
-    "# use resampled contours for training\n",
-    "train_contours = contours_resampled"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 5  ·  Train the ARTwarp network\n",
-    "\n",
-    "Key parameters:\n",
-    "\n",
-    "| Parameter | Meaning |\n",
-    "|-----------|--------|\n",
-    "| `vigilance` (ρ) | Match threshold 0–100 %. Higher → more, finer categories. |\n",
-    "| `learning_rate` | How fast prototypes update toward new members (0–1). |\n",
-    "| `bias` | Slightly deflates activation for new categories, favouring existing ones. |\n",
-    "| `warp_factor_level` | Maximum local time-compression/expansion allowed in DTW. |\n",
-    "| `max_iterations` | Upper bound on training passes over the dataset. |"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "network = ARTwarp(\n",
-    "    vigilance=96.0,\n",
-    "    learning_rate=0.01,\n",
-    "    bias=0.000001,\n",
-    "    max_categories=1800,\n",
-    "    max_iterations=1,\n",
-    "    warp_factor_level=3,\n",
-    "    random_seed=42,\n",
-    "    verbose=True,\n",
-    ")\n",
-    "\n",
-    "results = network.fit(train_contours, contour_names=names)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 6  ·  Inspect training results\n",
-    "\n",
-    "The `TrainingResults` object returned by `fit()` holds everything you need for post-hoc analysis."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f\"Categories formed  : {results.num_categories}\")\n",
-    "print(f\"Training iterations: {results.num_iterations}\")\n",
-    "print(f\"Converged          : {results.converged}\")\n",
-    "print(f\"Training time      : {results.training_time:.3f} s\")\n",
-    "print(f\"Uncategorized      : {results.get_uncategorized_count()}\")\n",
-    "print()\n",
-    "\n",
-    "sizes = results.get_category_sizes()\n",
-    "print(\"Category sizes:\")\n",
-    "for cat_id, count in sorted(sizes.items()):\n",
-    "    mask = results.categories == cat_id\n",
-    "    cat_matches = results.matches[mask]\n",
-    "    cat_matches = cat_matches[np.isfinite(cat_matches)]\n",
-    "    mean_m = np.mean(cat_matches) if len(cat_matches) else float('nan')\n",
-    "    members = [names[i] for i in range(len(names)) if results.categories[i] == cat_id]\n",
-    "    print(f\"  Category {cat_id}: {count:3d} contour(s)   mean match = {mean_m:.1f}%   {members}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 7  ·  Standard result visualizations\n",
-    "\n",
-    "### 7a  Training summary (multi-panel overview)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_training_summary(results, contour_names=names, figsize=(16, 10))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7b  Reference contours (category prototypes)\n",
-    "\n",
-    "Each panel shows the learned prototype contour for one category."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_reference_contours(results.weight_matrix)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7c  Category distribution"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_category_distribution(results, figsize=(9, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7d  Convergence history\n",
-    "\n",
-    "Shows reclassifications per iteration. The curve reaching zero (or near zero) means the network has converged."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_convergence_history(results, figsize=(9, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7e  Match score distribution\n",
-    "\n",
-    "Histogram of how well each contour matched its assigned prototype.  \n",
-    "A distribution clustered near 100 % means tight, well-separated categories."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_match_distribution(results, figsize=(9, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7f  Category discovery curve\n",
-    "\n",
-    "The curve rises each time a new category is first created and stays flat when a sample joins an existing one.  \n",
-    "A plateau indicates the dataset has revealed its full repertoire.  \n",
-    "This is the Python equivalent of the MATLAB `DiscoveryCurves.m` utility."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_discovery_curve(results, title=\"Example dataset\", figsize=(9, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7g  Contours in a specific category\n",
-    "\n",
-    "Overlays all contours assigned to one category with the reference prototype in red."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "first_cat = sorted(results.get_category_sizes())[0]\n",
-    "ref = results.weight_matrix[:, first_cat]\n",
-    "ref_clean = ref[~np.isnan(ref)]\n",
-    "\n",
-    "fig = plot_contours_by_category(\n",
-    "    train_contours, results.categories,\n",
-    "    category_id=first_cat,\n",
-    "    contour_names=names,\n",
-    "    reference_contour=ref_clean,\n",
-    "    figsize=(11, 6),\n",
-    ")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 8  ·  Algorithm diagrams\n",
-    "\n",
-    "These figures explain **how** ARTwarp works. They are useful for method sections of papers or presentations.\n",
-    "\n",
-    "### 8a  ARTwarp decision flow\n",
-    "\n",
-    "Shows the four-step per-sample decision loop: input → DTW to all prototypes → sort by activation → vigilance test → commit or new category."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_art_schematic(figsize=(13, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 8b  Itakura warping constraint\n",
-    "\n",
-    "The shaded region shows which cells in the alignment grid a DTW path is allowed to visit for `warp_factor_level = 3`.  \n",
-    "Cells outside the band are pruned — they represent implausible time-compressions or expansions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_warp_constraint(warp_factor_level=3, m=20, n=25, figsize=(6, 6))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 8c  DTW alignment path\n",
-    "\n",
-    "Left: the two contours overlaid. Right: the optimal warping path through the alignment grid (shaded = Itakura band; dotted = no-warp diagonal).\n",
-    "  \n",
-    "A path hugging the diagonal means the two contours are very similar in timing."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from artwarp.core.dtw import dynamic_time_warp\n",
-    "\n",
-    "wfl = 3\n",
-    "dtw_fig = None\n",
-    "for ci, ctr in enumerate(train_contours):\n",
-    "    cat = int(results.categories[ci])\n",
-    "    if cat >= results.weight_matrix.shape[1]:\n",
-    "        continue\n",
-    "    ref_col = results.weight_matrix[:, cat]\n",
-    "    ref_col = ref_col[~np.isnan(ref_col)]\n",
-    "    if len(ref_col) == 0:\n",
-    "        continue\n",
-    "    ratio = max(len(ctr), len(ref_col)) / max(1, min(len(ctr), len(ref_col)))\n",
-    "    if ratio < wfl:\n",
-    "        dtw_fig = plot_dtw_alignment(\n",
-    "            ctr, ref_col.astype(np.float64),\n",
-    "            warp_factor_level=wfl, figsize=(12, 5),\n",
-    "        )\n",
-    "        print(f\"Showing alignment for contour '{names[ci]}' vs its category {cat} prototype\")\n",
-    "        break\n",
-    "\n",
-    "if dtw_fig:\n",
-    "    plt.show()\n",
-    "else:\n",
-    "    print(\"No compatible pair found — try a higher warp_factor_level\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 9  ·  Diagnostic visualizations\n",
-    "\n",
-    "These figures help you assess the **quality** of the learned categories.\n",
-    "\n",
-    "### 9a  Per-category match quality\n",
-    "\n",
-    "Violin plot of match scores within each category.  \n",
-    "Narrow violins near 100 % indicate tight, cohesive categories.  \n",
-    "Wide or low-scoring violins may suggest that the category has mixed-type members."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_per_category_match_quality(results, figsize=(10, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 9b  Pairwise DTW similarity matrix\n",
-    "\n",
-    "Each cell shows the DTW similarity (%) between two category prototypes.  \n",
-    "The diagonal is always 100 % (a prototype compared to itself).  \n",
-    "High off-diagonal values reveal categories that are acoustically close and could potentially be merged."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_category_similarity_matrix(\n",
-    "    results.weight_matrix, warp_factor_level=3, figsize=(8, 7)\n",
-    ")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 9c  Acoustic space embedding (MDS)\n",
-    "\n",
-    "Pairwise DTW distances between all prototypes are reduced to 2D via classical Multidimensional Scaling.  \n",
-    "Points close together are acoustically similar; distant points are perceptually distinct call types.  \n",
-    "Dimension 1 captures the most variation; Dimension 2 the next most."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_category_embedding(\n",
-    "    results.weight_matrix, warp_factor_level=3, figsize=(8, 6)\n",
-    ")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 9d  Category dendrogram  *(requires scipy)*\n",
-    "\n",
-    "Hierarchical clustering of prototypes by DTW distance (average linkage).  \n",
-    "Categories that merge at low height are acoustically similar."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    fig = plot_category_dendrogram(\n",
-    "        results.weight_matrix, warp_factor_level=3, figsize=(10, 5)\n",
-    "    )\n",
-    "    plt.show()\n",
-    "except ImportError:\n",
-    "    print(\"scipy is not installed —> install with: pip install scipy\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 10  ·  Data-quality visualizations\n",
-    "\n",
-    "### 10a  Contour length & temporal resolution distributions\n",
-    "\n",
-    "Already shown in Section 3. Here we confirm the resampled dataset looks as expected."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "resampled_tempres = [SAMPLE_INTERVAL] * len(train_contours)\n",
-    "fig = plot_contour_length_distribution(\n",
-    "    train_contours,\n",
-    "    tempres_list=resampled_tempres,\n",
-    "    figsize=(13, 5),\n",
-    ")\n",
-    "plt.suptitle(\"After resampling to 5 ms\", fontsize=12, fontweight=\"bold\", y=1.02)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 11  ·  Parameter-study visualizations\n",
-    "\n",
-    "### 11a  Vigilance sweep\n",
-    "\n",
-    "Train the same dataset across a range of vigilance values and plot the resulting number of categories (left axis, blue) and mean match score (right axis, red).  \n",
-    "Use this to pick a vigilance that balances granularity vs. cohesion."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vigilance_values = [70.0, 75.0, 80.0, 85.0, 90.0, 95.0]\n",
-    "\n",
-    "sweep_results = [\n",
-    "    (\n",
-    "        v,\n",
-    "        ARTwarp(vigilance=v, random_seed=42, verbose=False).fit(train_contours),\n",
-    "    )\n",
-    "    for v in vigilance_values\n",
-    "]\n",
-    "\n",
-    "fig = plot_vigilance_sweep(sweep_results, figsize=(10, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 11b  Run stability\n",
-    "\n",
-    "Trains the network with the same settings but different random seeds (which shuffle presentation order).  \n",
-    "A tight distribution means the algorithm is stable regardless of order; a wide spread suggests order sensitivity."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n_cats_per_seed = [\n",
-    "    ARTwarp(vigilance=96.0, random_seed=s, verbose=False)\n",
-    "    .fit(train_contours)\n",
-    "    .num_categories\n",
-    "    for s in range(1)\n",
-    "]\n",
-    "\n",
-    "print(\"Categories per seed:\", n_cats_per_seed)\n",
-    "fig = plot_run_stability(n_cats_per_seed, figsize=(8, 5))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 12  ·  Publication figure\n",
-    "\n",
-    "`create_paper_figure` combines reference contours, discovery curve, and category distribution into a single multi-panel figure ready for a methods section."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = create_paper_figure(\n",
-    "    results,\n",
-    "    train_contours,\n",
-    "    contour_names=names,\n",
-    "    title=\"ARTwarp-py — Example Dataset\",\n",
-    "    figsize=(16, 10),\n",
-    ")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 13  ·  Ground-truth evaluation\n",
-    "\n",
-    "If you have external labels for recordings (e.g., manually identified whistle types), you can compare them to the categories ARTwarp discovered.\n",
-    "\n",
-    "For this, we construct **synthetic labels** to show how these plots work (needless to say, fake).  \n",
-    "In a real project you would load labels from a CSV or annotation file and align them to `names`.\n",
-    "\n",
-    "### How to provide labels in practice\n",
-    "\n",
-    "```python\n",
-    "# option 1 -> load from a CSV that has (filename, label) columns\n",
-    "import pandas as pd\n",
-    "label_df = pd.read_csv(\"labels.csv\", index_col=\"filename\")\n",
-    "labels = [label_df.loc[n, \"label\"] for n in names]\n",
-    "\n",
-    "# option 2 -> build a dict manually\n",
-    "label_map = {\"CSV001\": \"type_A\", \"CSV002\": \"type_B\", ...}\n",
-    "labels = [label_map[Path(n).stem] for n in names]\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# synthetic ground-truth labels for demonstration\n",
-    "# (In a real project these would come from your annotation file)\n",
-    "rng = np.random.default_rng(0)\n",
-    "possible_labels = [\"type_A\", \"type_B\", \"type_C\"]\n",
-    "synthetic_labels = rng.choice(possible_labels, size=len(names))\n",
-    "\n",
-    "# encode strings as integers (required by the plotting functions)\n",
-    "unique_labels = sorted(set(synthetic_labels))\n",
-    "label_ids = np.array([unique_labels.index(l) for l in synthetic_labels], dtype=int)\n",
-    "\n",
-    "print(\"Ground-truth label counts:\")\n",
-    "for lb in unique_labels:\n",
-    "    print(f\"  {lb}: {np.sum(synthetic_labels == lb)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 13a  Confusion matrix\n",
-    "\n",
-    "Rows = ground-truth label, columns = ARTwarp category.  \n",
-    "A perfect clustering would have each row dominated by a single column (and vice versa)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_confusion_matrix(\n",
-    "    label_ids,\n",
-    "    results.categories,\n",
-    "    figsize=(8, 6),\n",
-    ")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 13b  Label vs category distribution (stacked bar)\n",
-    "\n",
-    "For each ARTwarp category (x-axis), a stacked bar shows the proportion of each ground-truth label.\n",
-    "\n",
-    "A pure category has only one color; a mixed category has several.\n",
-    "\n",
-    "Complements the confusion matrix with a proportional view."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_label_vs_category(\n",
-    "    label_ids,\n",
-    "    results.categories,\n",
-    "    figsize=(10, 5),\n",
-    ")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 14  ·  Full automated report\n",
-    "\n",
-    "`create_results_report` writes all standard and additional figures to a directory in one call.  \n",
-    "This is equivalent to running `artwarp-py plot` from the CLI."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "REPORT_DIR = \"./artwarp_demo_report\"\n",
-    "\n",
-    "report_files = create_results_report(\n",
-    "    results,\n",
-    "    train_contours,\n",
-    "    contour_names=names,\n",
-    "    output_dir=REPORT_DIR,\n",
-    "    dpi=150,\n",
-    "    include_additional=True,   # generates additional/ subdirectory\n",
-    "    warp_factor_level=3,\n",
-    "    tempres_list=resampled_tempres,\n",
-    ")\n",
-    "\n",
-    "print(f\"\\nReport: {len(report_files)} figures saved to '{REPORT_DIR}/'\")\n",
-    "print(\"\\nMain directory figures:\")\n",
-    "for k, v in sorted(report_files.items()):\n",
-    "    if not k.startswith(\"additional\"):\n",
-    "        print(f\"  {k}: {v}\")\n",
-    "print(\"\\nAdditional figures:\")\n",
-    "for k, v in sorted(report_files.items()):\n",
-    "    if k.startswith(\"additional\"):\n",
-    "        print(f\"  {k}: {v}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 15  ·  Predict on new contours\n",
-    "\n",
-    "After training you can classify new, unseen contours without re-training.  \n",
-    "Use `network.predict()` — it returns category IDs and match scores."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Treat the original (pre-resampled) contours as \"new\" data\n",
-    "new_contours = contours_resampled[:3]\n",
-    "new_names    = names[:3]\n",
-    "\n",
-    "pred_categories, pred_matches = network.predict(new_contours)\n",
-    "\n",
-    "print(\"Predictions on new contours:\")\n",
-    "for name, cat, match in zip(new_names, pred_categories, pred_matches):\n",
-    "    print(f\"  {name:20s}  →  category {int(cat):2d}   match = {match:.1f}%\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 16  ·  Export results\n",
-    "\n",
-    "Three export functions cover the typical post-training workflow:\n",
-    "\n",
-    "| Function | Output |\n",
-    "|----------|--------|\n",
-    "| `export_results` | Pickled `TrainingResults` (`.pkl`) for later loading |\n",
-    "| `export_reference_contours` | CSV with one row per category prototype |\n",
-    "| `export_category_assignments` | CSV with one row per input contour (name, category, match) |"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.makedirs(\"artwarp_demo_output\", exist_ok=True)\n",
-    "\n",
-    "# 1. save full results (reload with artwarp.io.load_results)\n",
-    "export_results(results, \"artwarp_demo_output/results.pkl\")\n",
-    "\n",
-    "# 2. export reference contours -> one CSV per category written into the given directory\n",
-    "# (produces refContour_1.csv, refContour_2.csv, ... matching MATLAB SaveRefContours.m)\n",
-    "export_reference_contours(results.weight_matrix, \"artwarp_demo_output/reference_contours\")\n",
-    "\n",
-    "# 3. export per-contour assignments\n",
-    "export_category_assignments(\n",
-    "    results.categories, results.matches, names, \"artwarp_demo_output/assignments.csv\"\n",
-    ")\n",
-    "\n",
-    "print(\"Saved:\")\n",
-    "for f in sorted(os.listdir(\"artwarp_demo_output\")):\n",
-    "    size = os.path.getsize(f\"artwarp_demo_output/{f}\")\n",
-    "    print(f\"  artwarp_demo_output/{f}  ({size:,} bytes)\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# reload saved results\n",
-    "from artwarp.io import load_results\n",
-    "from artwarp.core.network import TrainingResults\n",
-    "\n",
-    "data = load_results(\"artwarp_demo_output/results.pkl\")\n",
-    "restored = TrainingResults(\n",
-    "    categories=data[\"categories\"],\n",
-    "    matches=data[\"matches\"],\n",
-    "    weight_matrix=data[\"weight_matrix\"],\n",
-    "    num_categories=data[\"num_categories\"],\n",
-    "    num_iterations=data[\"num_iterations\"],\n",
-    "    converged=data[\"converged\"],\n",
-    "    iteration_history=data[\"iteration_history\"],\n",
-    "    training_time=data[\"training_time\"],\n",
-    ")\n",
-    "print(f\"Restored: {restored.num_categories} categories, converged={restored.converged}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 17  ·  CLI quick reference\n",
-    "\n",
-    "Every step in this notebook can also be run from the terminal.\n",
-    "\n",
-    "### Train\n",
-    "```bash\n",
-    "artwarp-py train \\\n",
-    "    --input-dir  examples/data/ \\\n",
-    "    --output     results.pkl \\\n",
-    "    --format     csv \\\n",
-    "    --vigilance  85 \\\n",
-    "    --learning-rate 0.1 \\\n",
-    "    --bias       0.0 \\\n",
-    "    --max-categories 50 \\\n",
-    "    --max-iterations 50 \\\n",
-    "    --warp-factor 3 \\\n",
-    "    --seed       42 \\\n",
-    "    --resample   --sample-interval 0.005 \\\n",
-    "    --export-refs --export-categories\n",
-    "```\n",
-    "\n",
-    "### Generate report  (all figures + additional/)\n",
-    "```bash\n",
-    "artwarp-py plot \\\n",
-    "    --results    results.pkl \\\n",
-    "    --input-dir  examples/data/ \\\n",
-    "    --format     csv \\\n",
-    "    --output-dir ./report \\\n",
-    "    --dpi        300\n",
-    "```\n",
-    "\n",
-    "### Predict\n",
-    "```bash\n",
-    "artwarp-py predict \\\n",
-    "    --model      results.pkl \\\n",
-    "    --input-dir  examples/data/ \\\n",
-    "    --format     csv \\\n",
-    "    --output     predictions.csv\n",
-    "```\n",
-    "\n",
-    "### Help\n",
-    "```bash\n",
-    "artwarp-py --help\n",
-    "artwarp-py train --help\n",
-    "artwarp-py plot  --help\n",
-    "```\n",
-    "\n",
-    "---\n",
-    "*ARTwarp-py — Pedro Gronda Garrigues*"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "sig-process",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# ARTwarp-py — Demo & Guide\n",
+        "\n",
+        "A complete, runnable introduction to **ARTwarp-py**: load real contour files, train the network, interpret every result, and produce publication-quality* figures.\n",
+        "\n",
+        "**What this notebook covers**\n",
+        "\n",
+        "| Section | Topic |\n",
+        "|---------|-------|\n",
+        "| 1 | Imports & setup |\n",
+        "| 2 | Load real contours from `examples/data/` |\n",
+        "| 3 | Data exploration — length & temporal resolution |\n",
+        "| 4 | (Optional) Resampling to a common temporal resolution |\n",
+        "| 5 | Train the ARTwarp network |\n",
+        "| 5b | Optional training flags (MATLAB v2 & PR #10) |\n",
+        "| 6 | Inspect training results |\n",
+        "| 7 | Standard result visualizations |\n",
+        "| 8 | Algorithm diagrams |\n",
+        "| 9 | Diagnostic visualizations |\n",
+        "| 10 | Data-quality visualizations |\n",
+        "| 11 | Parameter-study visualizations |\n",
+        "| 12 | Publication figure |\n",
+        "| 13 | Ground-truth evaluation (confusion matrix, label map) |\n",
+        "| 14 | Full automated report |\n",
+        "| 15 | Predict on new contours |\n",
+        "| 16 | Export results |\n",
+        "| 17 | CLI quick reference |\n",
+        "\n",
+        "> **Docs:** `docs/user/API.md` · `docs/user/QUICK_REFERENCE.md` · `docs/user/VISUALIZATION.md`  \n",
+        "> **CLI / menu:** `artwarp-py train --help` · `./run.sh` (interactive Train / Plot / …; prompts for MATLAB parity + optional PR #10 flags)\n",
+        "\n",
+        "*Always double check figure for DPI, dimension, etc, before publication.\n",
+        "\n",
+        "@author: Pedro Gronda Garrigues"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 1  ·  Imports & setup\n",
+        "\n",
+        "Install the package once from the project root: `pip install -e .`  \n",
+        "All cells below require only `artwarp`, `numpy`, and `matplotlib`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import matplotlib\n",
+        "matplotlib.rcParams['figure.dpi'] = 110\n",
+        "\n",
+        "from pathlib import Path\n",
+        "\n",
+        "# core API\n",
+        "from artwarp import ARTwarp, load_contours, purge_empty_category_columns\n",
+        "from artwarp.utils import resample_contours\n",
+        "from artwarp.io.exporters import (\n",
+        "    export_results,\n",
+        "    export_reference_contours,\n",
+        "    export_category_assignments,\n",
+        ")\n",
+        "\n",
+        "# all visualization functions\n",
+        "from artwarp.visualization import (\n",
+        "    create_paper_figure,\n",
+        "    create_results_report,\n",
+        "    plot_art_schematic,\n",
+        "    plot_category_distribution,\n",
+        "    plot_category_embedding,\n",
+        "    plot_category_similarity_matrix,\n",
+        "    plot_category_dendrogram,\n",
+        "    plot_confusion_matrix,\n",
+        "    plot_contour_length_distribution,\n",
+        "    plot_contours_by_category,\n",
+        "    plot_convergence_history,\n",
+        "    plot_discovery_curve,\n",
+        "    plot_dtw_alignment,\n",
+        "    plot_label_vs_category,\n",
+        "    plot_match_distribution,\n",
+        "    plot_per_category_match_quality,\n",
+        "    plot_reference_contours,\n",
+        "    plot_resampling_before_after,\n",
+        "    plot_run_stability,\n",
+        "    plot_training_summary,\n",
+        "    plot_vigilance_sweep,\n",
+        "    plot_warp_constraint,\n",
+        ")\n",
+        "\n",
+        "import artwarp\n",
+        "print(f\"artwarp-py  version: {artwarp.__version__}\")\n",
+        "print(f\"numpy       version: {np.__version__}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 2  ·  Load real contours from `examples/data/`\n",
+        "\n",
+        "The `data/` directory contains five dolphin-whistle contour CSV files (columns: `Time [ms]`, `Peak Frequency [Hz]`). These were kindly provided by @Kai Kerlaff, and are in the latest release of ARTwarp (MATLAB version).\n",
+        " \n",
+        "`load_contours` auto-detects the frequency and time columns.  \n",
+        "Passing `return_tempres=True` also returns the per-file temporal resolution inferred from the time column."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DATA_DIR = Path(\"../contours-sarasota\")   # relative to examples/\n",
+        "# DATA_DIR = Path(\"../contours\")\n",
+        "\n",
+        "contours, names, tempres_list = load_contours(\n",
+        "    str(DATA_DIR),\n",
+        "    file_format=\"auto\",\n",
+        "    return_tempres=True,\n",
+        ")\n",
+        "\n",
+        "print(f\"Loaded {len(contours)} contours\")\n",
+        "for name, ctr, tr in zip(names, contours, tempres_list):\n",
+        "    print(f\"  {name:20s}  length={len(ctr):4d} pts   tempres={tr:.4f} s/pt   \"\n",
+        "          f\"duration={len(ctr)*tr*1000:.1f} ms   \"\n",
+        "          f\"freq=[{ctr.min():.0f}, {ctr.max():.0f}] Hz\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 3  ·  Data exploration — length & temporal resolution\n",
+        "\n",
+        "Before training it is good practice to understand your dataset's shape.  \n",
+        "`plot_contour_length_distribution` gives you histograms of both contour length (in samples) and temporal resolution (seconds per sample) in one figure.\n",
+        "\n",
+        "Contours with very different temporal resolutions should be resampled to a common interval before training (see Section 4)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_contour_length_distribution(\n",
+        "    contours,\n",
+        "    tempres_list=tempres_list,\n",
+        "    figsize=(13, 5),\n",
+        ")\n",
+        "plt.show()\n",
+        "\n",
+        "# TODO: fix temporal resolution distribution plot"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 4  ·  (Optional) Resampling to a common temporal resolution\n",
+        "\n",
+        "If your files have different temporal resolutions (e.g., 5 ms vs 10 ms per sample), DTW comparisons can be misleading because one contour appears longer than it physically is.  \n",
+        "Resampling interpolates every contour to the same time step.\n",
+        "\n",
+        "`plot_resampling_before_after` shows the effect on a single contour so you can sanity-check the result."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# SAMPLE_INTERVAL = 0.005  # 5 ms per sample -> keeps original resolution for this dataset\n",
+        "SAMPLE_INTERVAL = 0.010\n",
+        "\n",
+        "# visualise what resampling to 10 ms would look like on the first contour\n",
+        "fig = plot_resampling_before_after(\n",
+        "    contours[0],\n",
+        "    tempres=tempres_list[0],\n",
+        "    sample_interval_sec=0.010,\n",
+        "    title=f\"resampling demo — {names[0]}\",\n",
+        "    figsize=(12, 5),\n",
+        ")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# apply resampling (resample to 5 ms to normalise any small differences)\n",
+        "contours_resampled = resample_contours(contours, tempres_list, SAMPLE_INTERVAL)\n",
+        "\n",
+        "print(\"Contour lengths before and after resampling:\")\n",
+        "for name, orig, resampled in zip(names, contours, contours_resampled):\n",
+        "    print(f\"  {name:20s}  {len(orig):4d} → {len(resampled):4d} pts\")\n",
+        "\n",
+        "# use resampled contours for training\n",
+        "train_contours = contours_resampled"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 5  ·  Train the ARTwarp network\n",
+        "\n",
+        "Key parameters:\n",
+        "\n",
+        "| Parameter | Meaning |\n",
+        "|-----------|--------|\n",
+        "| `vigilance` (ρ) | Match threshold 0–100 %. Higher → more, finer categories. |\n",
+        "| `learning_rate` | How fast prototypes update toward new members (0–1). |\n",
+        "| `bias` | Activation bias [0,1]. The **`artwarp-py train`** CLI defaults to **1e-6** (MATLAB `ARTwarp_cli_mode.m`); the Python class defaults **0.0** unless you set it. |\n",
+        "| `warp_factor_level` | Maximum local time-compression/expansion allowed in DTW. |\n",
+        "| `max_iterations` | Upper bound on training passes over the dataset. |\n",
+        "\n",
+        "**Optional — MATLAB `stable` (`ARTwarp_Run_Categorisation.m`)**\n",
+        "\n",
+        "| Parameter | Default | Meaning |\n",
+        "|-----------|---------|--------|\n",
+        "| `recat_single_categories` | `False` | After each iteration: lone-contour recat (`ARTwarp_Recat_Single_Cats`). CLI: `--recat-single-categories`. |\n",
+        "| `compare_warped` | `False` | Compare-warped weight updates + `average_weights` each iteration. CLI: `--compare-warped`. |\n",
+        "\n",
+        "**Optional — PR #10 extensions** (merge `f671e5a`, *not* in MATLAB `stable`)\n",
+        "\n",
+        "| Parameter | Default | Meaning |\n",
+        "|-----------|---------|--------|\n",
+        "| `deprioritize_lone_category_search` | `False` | If a sample is alone in its category, try other prototypes *before* its own in the search order. CLI: `--deprioritize-lone-category-search`. |\n",
+        "| `purge_empty_categories` | `False` | After each iteration, drop weight columns with *no* assigned contours. CLI: `--purge-empty-categories`. Helper: `purge_empty_category_columns()` in `artwarp.core.weights`. |\n",
+        "\n",
+        "The cell below sets all optional flags to **`False`** to match a plain MATLAB run; see **§5b** to try the extras."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "network = ARTwarp(\n",
+        "    vigilance=96.0,\n",
+        "    learning_rate=0.01,\n",
+        "    bias=0.000001,  # 1e-6 — same order of magnitude as `artwarp-py train` (MATLAB CLI default)\n",
+        "    max_categories=1800,\n",
+        "    max_iterations=1,\n",
+        "    warp_factor_level=3,\n",
+        "    random_seed=42,\n",
+        "    verbose=True,\n",
+        "    # --- MATLAB optional (v2.0) ---\n",
+        "    recat_single_categories=False,\n",
+        "    compare_warped=False,\n",
+        "    # --- optional (not in MATLAB stable v2.0) ---\n",
+        "    deprioritize_lone_category_search=False,\n",
+        "    purge_empty_categories=False,\n",
+        ")\n",
+        "\n",
+        "results = network.fit(train_contours, contour_names=names)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 5b  ·  Optional training flags (MATLAB v2 & Marco's delete_unused_categories)\n",
+        "\n",
+        "- **MATLAB parity:** `recat_single_categories` / `compare_warped` mirror the GUI/CLI options on branch **`stable`** (`ARTwarp_Run_Categorisation.m`).\n",
+        "- **PR experimental (`martion2007/delete_unused_categories`): `deprioritize_lone_category_search` changes resonance search order for lone-category samples; `purge_empty_categories` removes orphan prototype columns each iteration. Both default **off**.\n",
+        "\n",
+        "Set **`RUN_EXTENDED_FLAG_DEMO = True`** in the next cell for a **short** second training run with **all** optional flags enabled (uses a different random seed so results differ from §5)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# toy illustration: orphan-column purge (same logic as purge_empty_categories in fit)\n",
+        "_demo_w = np.ones((4, 3), dtype=np.float64)\n",
+        "_demo_c = np.array([0.0, 0.0, 2.0], dtype=np.float64)\n",
+        "_nw, _nc, _nremoved = purge_empty_category_columns(_demo_w, _demo_c)\n",
+        "print(\n",
+        "    f\"purge_empty_category_columns (PR #10): removed {_nremoved} empty column(s), \"\n",
+        "    f\"shape {_demo_w.shape} → {_nw.shape}\"\n",
+        ")\n",
+        "\n",
+        "# optional second training run with every flag on (increases runtime)\n",
+        "RUN_EXTENDED_FLAG_DEMO = False\n",
+        "\n",
+        "if RUN_EXTENDED_FLAG_DEMO:\n",
+        "    net_ext = ARTwarp(\n",
+        "        vigilance=96.0,\n",
+        "        learning_rate=0.01,\n",
+        "        bias=1e-6,\n",
+        "        max_categories=1800,\n",
+        "        max_iterations=3,\n",
+        "        warp_factor_level=3,\n",
+        "        random_seed=43,\n",
+        "        verbose=True,\n",
+        "        recat_single_categories=True,\n",
+        "        compare_warped=True,\n",
+        "        deprioritize_lone_category_search=True,\n",
+        "        purge_empty_categories=True,\n",
+        "    )\n",
+        "    results_ext = net_ext.fit(train_contours, contour_names=names)\n",
+        "    print(\n",
+        "        f\"Extended-flag run: {results_ext.num_categories} categories, \"\n",
+        "        f\"converged={results_ext.converged}\"\n",
+        "    )\n",
+        "else:\n",
+        "    print(\"Optional demo skipped (set RUN_EXTENDED_FLAG_DEMO = True to run).\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 6  ·  Inspect training results\n",
+        "\n",
+        "The `TrainingResults` object returned by `fit()` holds everything you need for post-hoc analysis."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "print(f\"Categories formed  : {results.num_categories}\")\n",
+        "print(f\"Training iterations: {results.num_iterations}\")\n",
+        "print(f\"Converged          : {results.converged}\")\n",
+        "print(f\"Training time      : {results.training_time:.3f} s\")\n",
+        "print(f\"Uncategorized      : {results.get_uncategorized_count()}\")\n",
+        "print()\n",
+        "\n",
+        "sizes = results.get_category_sizes()\n",
+        "print(\"Category sizes:\")\n",
+        "for cat_id, count in sorted(sizes.items()):\n",
+        "    mask = results.categories == cat_id\n",
+        "    cat_matches = results.matches[mask]\n",
+        "    cat_matches = cat_matches[np.isfinite(cat_matches)]\n",
+        "    mean_m = np.mean(cat_matches) if len(cat_matches) else float('nan')\n",
+        "    members = [names[i] for i in range(len(names)) if results.categories[i] == cat_id]\n",
+        "    print(f\"  Category {cat_id}: {count:3d} contour(s)   mean match = {mean_m:.1f}%   {members}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 7  ·  Standard result visualizations\n",
+        "\n",
+        "### 7a  Training summary (multi-panel overview)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_training_summary(results, contour_names=names, figsize=(16, 10))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 7b  Reference contours (category prototypes)\n",
+        "\n",
+        "Each panel shows the learned prototype contour for one category."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_reference_contours(results.weight_matrix)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 7c  Category distribution"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_category_distribution(results, figsize=(9, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 7d  Convergence history\n",
+        "\n",
+        "Shows reclassifications per iteration. The curve reaching zero (or near zero) means the network has converged."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_convergence_history(results, figsize=(9, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 7e  Match score distribution\n",
+        "\n",
+        "Histogram of how well each contour matched its assigned prototype.  \n",
+        "A distribution clustered near 100 % means tight, well-separated categories."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_match_distribution(results, figsize=(9, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 7f  Category discovery curve\n",
+        "\n",
+        "The curve rises each time a new category is first created and stays flat when a sample joins an existing one.  \n",
+        "A plateau indicates the dataset has revealed its full repertoire.  \n",
+        "This is the Python equivalent of the MATLAB `DiscoveryCurves.m` utility."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_discovery_curve(results, title=\"Example dataset\", figsize=(9, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 7g  Contours in a specific category\n",
+        "\n",
+        "Overlays all contours assigned to one category with the reference prototype in red."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "first_cat = sorted(results.get_category_sizes())[0]\n",
+        "ref = results.weight_matrix[:, first_cat]\n",
+        "ref_clean = ref[~np.isnan(ref)]\n",
+        "\n",
+        "fig = plot_contours_by_category(\n",
+        "    train_contours, results.categories,\n",
+        "    category_id=first_cat,\n",
+        "    contour_names=names,\n",
+        "    reference_contour=ref_clean,\n",
+        "    figsize=(11, 6),\n",
+        ")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 8  ·  Algorithm diagrams\n",
+        "\n",
+        "These figures explain **how** ARTwarp works. They are useful for method sections of papers or presentations.\n",
+        "\n",
+        "### 8a  ARTwarp decision flow\n",
+        "\n",
+        "Shows the four-step per-sample decision loop: input → DTW to all prototypes → sort by activation → vigilance test → commit or new category."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_art_schematic(figsize=(13, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 8b  Itakura warping constraint\n",
+        "\n",
+        "The shaded region shows which cells in the alignment grid a DTW path is allowed to visit for `warp_factor_level = 3`.  \n",
+        "Cells outside the band are pruned — they represent implausible time-compressions or expansions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_warp_constraint(warp_factor_level=3, m=20, n=25, figsize=(6, 6))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 8c  DTW alignment path\n",
+        "\n",
+        "Left: the two contours overlaid. Right: the optimal warping path through the alignment grid (shaded = Itakura band; dotted = no-warp diagonal).\n",
+        "  \n",
+        "A path hugging the diagonal means the two contours are very similar in timing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from artwarp.core.dtw import dynamic_time_warp\n",
+        "\n",
+        "wfl = 3\n",
+        "dtw_fig = None\n",
+        "for ci, ctr in enumerate(train_contours):\n",
+        "    cat = int(results.categories[ci])\n",
+        "    if cat >= results.weight_matrix.shape[1]:\n",
+        "        continue\n",
+        "    ref_col = results.weight_matrix[:, cat]\n",
+        "    ref_col = ref_col[~np.isnan(ref_col)]\n",
+        "    if len(ref_col) == 0:\n",
+        "        continue\n",
+        "    ratio = max(len(ctr), len(ref_col)) / max(1, min(len(ctr), len(ref_col)))\n",
+        "    if ratio < wfl:\n",
+        "        dtw_fig = plot_dtw_alignment(\n",
+        "            ctr, ref_col.astype(np.float64),\n",
+        "            warp_factor_level=wfl, figsize=(12, 5),\n",
+        "        )\n",
+        "        print(f\"Showing alignment for contour '{names[ci]}' vs its category {cat} prototype\")\n",
+        "        break\n",
+        "\n",
+        "if dtw_fig:\n",
+        "    plt.show()\n",
+        "else:\n",
+        "    print(\"No compatible pair found — try a higher warp_factor_level\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 9  ·  Diagnostic visualizations\n",
+        "\n",
+        "These figures help you assess the **quality** of the learned categories.\n",
+        "\n",
+        "### 9a  Per-category match quality\n",
+        "\n",
+        "Violin plot of match scores within each category.  \n",
+        "Narrow violins near 100 % indicate tight, cohesive categories.  \n",
+        "Wide or low-scoring violins may suggest that the category has mixed-type members."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_per_category_match_quality(results, figsize=(10, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 9b  Pairwise DTW similarity matrix\n",
+        "\n",
+        "Each cell shows the DTW similarity (%) between two category prototypes.  \n",
+        "The diagonal is always 100 % (a prototype compared to itself).  \n",
+        "High off-diagonal values reveal categories that are acoustically close and could potentially be merged."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_category_similarity_matrix(\n",
+        "    results.weight_matrix, warp_factor_level=3, figsize=(8, 7)\n",
+        ")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 9c  Acoustic space embedding (MDS)\n",
+        "\n",
+        "Pairwise DTW distances between all prototypes are reduced to 2D via classical Multidimensional Scaling.  \n",
+        "Points close together are acoustically similar; distant points are perceptually distinct call types.  \n",
+        "Dimension 1 captures the most variation; Dimension 2 the next most."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_category_embedding(\n",
+        "    results.weight_matrix, warp_factor_level=3, figsize=(8, 6)\n",
+        ")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 9d  Category dendrogram  *(requires scipy)*\n",
+        "\n",
+        "Hierarchical clustering of prototypes by DTW distance (average linkage).  \n",
+        "Categories that merge at low height are acoustically similar."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    fig = plot_category_dendrogram(\n",
+        "        results.weight_matrix, warp_factor_level=3, figsize=(10, 5)\n",
+        "    )\n",
+        "    plt.show()\n",
+        "except ImportError:\n",
+        "    print(\"scipy is not installed —> install with: pip install scipy\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 10  ·  Data-quality visualizations\n",
+        "\n",
+        "### 10a  Contour length & temporal resolution distributions\n",
+        "\n",
+        "Already shown in Section 3. Here we confirm the resampled dataset looks as expected."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "resampled_tempres = [SAMPLE_INTERVAL] * len(train_contours)\n",
+        "fig = plot_contour_length_distribution(\n",
+        "    train_contours,\n",
+        "    tempres_list=resampled_tempres,\n",
+        "    figsize=(13, 5),\n",
+        ")\n",
+        "plt.suptitle(\"After resampling to 5 ms\", fontsize=12, fontweight=\"bold\", y=1.02)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 11  ·  Parameter-study visualizations\n",
+        "\n",
+        "### 11a  Vigilance sweep\n",
+        "\n",
+        "Train the same dataset across a range of vigilance values and plot the resulting number of categories (left axis, blue) and mean match score (right axis, red).  \n",
+        "Use this to pick a vigilance that balances granularity vs. cohesion."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "vigilance_values = [70.0, 75.0, 80.0, 85.0, 90.0, 95.0]\n",
+        "\n",
+        "sweep_results = [\n",
+        "    (\n",
+        "        v,\n",
+        "        ARTwarp(vigilance=v, random_seed=42, verbose=False).fit(train_contours),\n",
+        "    )\n",
+        "    for v in vigilance_values\n",
+        "]\n",
+        "\n",
+        "fig = plot_vigilance_sweep(sweep_results, figsize=(10, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 11b  Run stability\n",
+        "\n",
+        "Trains the network with the same settings but different random seeds (which shuffle presentation order).  \n",
+        "A tight distribution means the algorithm is stable regardless of order; a wide spread suggests order sensitivity."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "n_cats_per_seed = [\n",
+        "    ARTwarp(vigilance=96.0, random_seed=s, verbose=False)\n",
+        "    .fit(train_contours)\n",
+        "    .num_categories\n",
+        "    for s in range(1)\n",
+        "]\n",
+        "\n",
+        "print(\"Categories per seed:\", n_cats_per_seed)\n",
+        "fig = plot_run_stability(n_cats_per_seed, figsize=(8, 5))\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 12  ·  Publication figure\n",
+        "\n",
+        "`create_paper_figure` combines reference contours, discovery curve, and category distribution into a single multi-panel figure ready for a methods section."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = create_paper_figure(\n",
+        "    results,\n",
+        "    train_contours,\n",
+        "    contour_names=names,\n",
+        "    title=\"ARTwarp-py — Example Dataset\",\n",
+        "    figsize=(16, 10),\n",
+        ")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 13  ·  Ground-truth evaluation\n",
+        "\n",
+        "If you have external labels for recordings (e.g., manually identified whistle types), you can compare them to the categories ARTwarp discovered.\n",
+        "\n",
+        "For this, we construct **synthetic labels** to show how these plots work (needless to say, fake).  \n",
+        "In a real project you would load labels from a CSV or annotation file and align them to `names`.\n",
+        "\n",
+        "### How to provide labels in practice\n",
+        "\n",
+        "```python\n",
+        "# option 1 -> load from a CSV that has (filename, label) columns\n",
+        "import pandas as pd\n",
+        "label_df = pd.read_csv(\"labels.csv\", index_col=\"filename\")\n",
+        "labels = [label_df.loc[n, \"label\"] for n in names]\n",
+        "\n",
+        "# option 2 -> build a dict manually\n",
+        "label_map = {\"CSV001\": \"type_A\", \"CSV002\": \"type_B\", ...}\n",
+        "labels = [label_map[Path(n).stem] for n in names]\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# synthetic ground-truth labels for demonstration\n",
+        "# (In a real project these would come from your annotation file)\n",
+        "rng = np.random.default_rng(0)\n",
+        "possible_labels = [\"type_A\", \"type_B\", \"type_C\"]\n",
+        "synthetic_labels = rng.choice(possible_labels, size=len(names))\n",
+        "\n",
+        "# encode strings as integers (required by the plotting functions)\n",
+        "unique_labels = sorted(set(synthetic_labels))\n",
+        "label_ids = np.array([unique_labels.index(l) for l in synthetic_labels], dtype=int)\n",
+        "\n",
+        "print(\"Ground-truth label counts:\")\n",
+        "for lb in unique_labels:\n",
+        "    print(f\"  {lb}: {np.sum(synthetic_labels == lb)}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 13a  Confusion matrix\n",
+        "\n",
+        "Rows = ground-truth label, columns = ARTwarp category.  \n",
+        "A perfect clustering would have each row dominated by a single column (and vice versa)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_confusion_matrix(\n",
+        "    label_ids,\n",
+        "    results.categories,\n",
+        "    figsize=(8, 6),\n",
+        ")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 13b  Label vs category distribution (stacked bar)\n",
+        "\n",
+        "For each ARTwarp category (x-axis), a stacked bar shows the proportion of each ground-truth label.\n",
+        "\n",
+        "A pure category has only one color; a mixed category has several.\n",
+        "\n",
+        "Complements the confusion matrix with a proportional view."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plot_label_vs_category(\n",
+        "    label_ids,\n",
+        "    results.categories,\n",
+        "    figsize=(10, 5),\n",
+        ")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 14  ·  Full automated report\n",
+        "\n",
+        "`create_results_report` writes all standard and additional figures to a directory in one call.  \n",
+        "This is equivalent to running `artwarp-py plot` from the CLI."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "REPORT_DIR = \"./artwarp_demo_report\"\n",
+        "\n",
+        "report_files = create_results_report(\n",
+        "    results,\n",
+        "    train_contours,\n",
+        "    contour_names=names,\n",
+        "    output_dir=REPORT_DIR,\n",
+        "    dpi=150,\n",
+        "    include_additional=True,   # generates additional/ subdirectory\n",
+        "    warp_factor_level=3,\n",
+        "    tempres_list=resampled_tempres,\n",
+        ")\n",
+        "\n",
+        "print(f\"\\nReport: {len(report_files)} figures saved to '{REPORT_DIR}/'\")\n",
+        "print(\"\\nMain directory figures:\")\n",
+        "for k, v in sorted(report_files.items()):\n",
+        "    if not k.startswith(\"additional\"):\n",
+        "        print(f\"  {k}: {v}\")\n",
+        "print(\"\\nAdditional figures:\")\n",
+        "for k, v in sorted(report_files.items()):\n",
+        "    if k.startswith(\"additional\"):\n",
+        "        print(f\"  {k}: {v}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 15  ·  Predict on new contours\n",
+        "\n",
+        "After training you can classify new, unseen contours without re-training.  \n",
+        "Use `network.predict()` — it returns category IDs and match scores."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Treat the original (pre-resampled) contours as \"new\" data\n",
+        "new_contours = contours_resampled[:3]\n",
+        "new_names    = names[:3]\n",
+        "\n",
+        "pred_categories, pred_matches = network.predict(new_contours)\n",
+        "\n",
+        "print(\"Predictions on new contours:\")\n",
+        "for name, cat, match in zip(new_names, pred_categories, pred_matches):\n",
+        "    print(f\"  {name:20s}  →  category {int(cat):2d}   match = {match:.1f}%\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 16  ·  Export results\n",
+        "\n",
+        "Three export functions cover the typical post-training workflow:\n",
+        "\n",
+        "| Function | Output |\n",
+        "|----------|--------|\n",
+        "| `export_results` | Pickled `TrainingResults` (`.pkl`) for later loading |\n",
+        "| `export_reference_contours` | CSV with one row per category prototype |\n",
+        "| `export_category_assignments` | CSV with one row per input contour (name, category, match) |"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "os.makedirs(\"artwarp_demo_output\", exist_ok=True)\n",
+        "\n",
+        "# 1. save full results (reload with artwarp.io.load_results)\n",
+        "export_results(results, \"artwarp_demo_output/results.pkl\")\n",
+        "\n",
+        "# 2. export reference contours -> one CSV per category written into the given directory\n",
+        "# (produces refContour_1.csv, refContour_2.csv, ... matching MATLAB SaveRefContours.m)\n",
+        "export_reference_contours(results.weight_matrix, \"artwarp_demo_output/reference_contours\")\n",
+        "\n",
+        "# 3. export per-contour assignments\n",
+        "export_category_assignments(\n",
+        "    results.categories, results.matches, names, \"artwarp_demo_output/assignments.csv\"\n",
+        ")\n",
+        "\n",
+        "print(\"Saved:\")\n",
+        "for f in sorted(os.listdir(\"artwarp_demo_output\")):\n",
+        "    size = os.path.getsize(f\"artwarp_demo_output/{f}\")\n",
+        "    print(f\"  artwarp_demo_output/{f}  ({size:,} bytes)\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# reload saved results\n",
+        "from artwarp.io import load_results\n",
+        "from artwarp.core.network import TrainingResults\n",
+        "\n",
+        "data = load_results(\"artwarp_demo_output/results.pkl\")\n",
+        "restored = TrainingResults(\n",
+        "    categories=data[\"categories\"],\n",
+        "    matches=data[\"matches\"],\n",
+        "    weight_matrix=data[\"weight_matrix\"],\n",
+        "    num_categories=data[\"num_categories\"],\n",
+        "    num_iterations=data[\"num_iterations\"],\n",
+        "    converged=data[\"converged\"],\n",
+        "    iteration_history=data[\"iteration_history\"],\n",
+        "    training_time=data[\"training_time\"],\n",
+        ")\n",
+        "print(f\"Restored: {restored.num_categories} categories, converged={restored.converged}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 17  ·  CLI quick reference\n",
+        "\n",
+        "Every step in this notebook can also be run from the terminal.\n",
+        "\n",
+        "**Defaults** (see `ARTwarp_cli_mode.m`): `train` resamples **on** (`--sample-interval` default **0.01** s), **`--bias`** default **1e-6**. Use **`--no-resample`** to turn resampling off.\n",
+        "\n",
+        "### Train (MATLAB-aligned defaults + exports)\n",
+        "```bash\n",
+        "artwarp-py train \\\n",
+        "    --input-dir  examples/data/ \\\n",
+        "    --output     results.pkl \\\n",
+        "    --format     csv \\\n",
+        "    --vigilance  85 \\\n",
+        "    --learning-rate 0.1 \\\n",
+        "    --max-categories 50 \\\n",
+        "    --max-iterations 50 \\\n",
+        "    --warp-factor 3 \\\n",
+        "    --seed       42 \\\n",
+        "    --export-refs --export-categories\n",
+        "# --bias defaults to 1e-6; resample defaults on (add --sample-interval 0.01 --tempres 0.01 to be explicit)\n",
+        "```\n",
+        "\n",
+        "### Train (optional MATLAB v2.0 + experimental — same flags as §5 / §5b)\n",
+        "```bash\n",
+        "artwarp-py train -i examples/data/ -o results_extended.pkl --format csv \\\n",
+        "    --recat-single-categories \\\n",
+        "    --compare-warped \\\n",
+        "    --deprioritize-lone-category-search \\\n",
+        "    --purge-empty-categories\n",
+        "```\n",
+        "\n",
+        "### Generate report  (all figures + additional/)\n",
+        "```bash\n",
+        "artwarp-py plot \\\n",
+        "    --results    results.pkl \\\n",
+        "    --input-dir  examples/data/ \\\n",
+        "    --format     csv \\\n",
+        "    --output-dir ./report \\\n",
+        "    --dpi        300\n",
+        "```\n",
+        "\n",
+        "### Predict\n",
+        "```bash\n",
+        "artwarp-py predict \\\n",
+        "    --model      results.pkl \\\n",
+        "    --input-dir  examples/data/ \\\n",
+        "    --format     csv \\\n",
+        "    --output     predictions.csv\n",
+        "```\n",
+        "\n",
+        "### Help\n",
+        "```bash\n",
+        "artwarp-py --help\n",
+        "artwarp-py train --help\n",
+        "artwarp-py plot  --help\n",
+        "```\n",
+        "\n",
+        "---\n",
+        "*ARTwarp-py — Pedro Gronda Garrigues*"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "sig-process",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.14.2"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,9 @@
 # ARTwarp-py — interactive launcher and CLI entry point
 #
 # Interactive (no args): menu to configure and run train / plot / predict / export
-#   with prompts for every CLI option, defaults, and validation.
+#   with prompts for every CLI option, defaults, and validation (Train includes MATLAB
+#   parity for v2.0: recatSingleCats, compareWarped — same as artwarp-py --recat-single-categories / --compare-warped).
+#   Optional extensions: --deprioritize-lone-category-search, --purge-empty-categories.
 # Direct (with args): forwards to artwarp-py (e.g. ./run.sh train -i ./contours -o results.pkl).
 #
 # Usage:
@@ -274,7 +276,7 @@ run_train() {
   args+=(--vigilance "$vigilance")
   learning_rate=$(prompt_with_default "Learning rate (0–1)" "0.1" learning_rate_01)
   args+=(--learning-rate "$learning_rate")
-  bias=$(prompt_with_default "Bias (0–1)" "0.0" bias_01)
+  bias=$(prompt_with_default "Bias (0–1)" "0.000001" bias_01)
   args+=(--bias "$bias")
   max_categories=$(prompt_with_default "Max categories" "50" int_positive)
   args+=(--max-categories "$max_categories")
@@ -285,13 +287,30 @@ run_train() {
   seed=$(prompt_with_default "Random seed (empty = none)" "" optional_int)
   [[ -n "$seed" ]] && args+=(--seed "$seed")
 
-  subheader "Resampling (optional)"
-  if prompt_yesno "Resample contours to uniform temporal resolution?" "n"; then
-    args+=(--resample)
-    sample_interval=$(prompt_with_default "Sample interval (seconds)" "0.02" float)
+  subheader "MATLAB ARTwarp v2.0 parity (optional)"
+  if prompt_yesno "Recategorise single-whistle categories (SWCs)?" "n"; then
+    args+=(--recat-single-categories)
+  fi
+  if prompt_yesno "Compare warped / average weights per iteration?" "n"; then
+    args+=(--compare-warped)
+  fi
+
+  subheader "Optional purge empty categories / deprioritize lone-category search order experimental training extensions (non-MATLAB stable v2.0)"
+  if prompt_yesno "Deprioritize lone-category search order (try other cats first)?" "n"; then
+    args+=(--deprioritize-lone-category-search)
+  fi
+  if prompt_yesno "Purge orphan weight columns (zero assigned contours per iter)?" "n"; then
+    args+=(--purge-empty-categories)
+  fi
+
+  subheader "Resampling (MATLAB ARTwarp_cli_mode: default on)"
+  if prompt_yesno "Resample contours to uniform temporal resolution?" "y"; then
+    sample_interval=$(prompt_with_default "Sample interval (seconds)" "0.01" float)
     args+=(--sample-interval "$sample_interval")
     tempres=$(prompt_with_default "Default tempres (sec/point)" "0.01" float)
     args+=(--tempres "$tempres")
+  else
+    args+=(--no-resample)
   fi
   max_contour_length=$(prompt_with_default "Max contour length (empty = no cap)" "" optional_int)
   [[ -n "$max_contour_length" ]] && args+=(--max-contour-length "$max_contour_length")

--- a/src/artwarp/__init__.py
+++ b/src/artwarp/__init__.py
@@ -27,6 +27,7 @@ Example:
 """
 
 from artwarp.core.network import ARTwarp
+from artwarp.core.weights import purge_empty_category_columns
 from artwarp.io.loaders import load_contours
 from artwarp.utils.numba_check import numba_available, report_numba_status
 
@@ -39,4 +40,4 @@ if numba_available():
 # from artwarp.visualization import plot_training_summary
 
 __version__ = "1.0.1"
-__all__ = ["ARTwarp", "load_contours"]
+__all__ = ["ARTwarp", "load_contours", "purge_empty_category_columns"]

--- a/src/artwarp/cli/main.py
+++ b/src/artwarp/cli/main.py
@@ -35,7 +35,7 @@ def command_train(args: argparse.Namespace) -> None:
     """Execute the train command."""
     print(f"Loading contours from: {args.input_dir}")
 
-    need_tempres = getattr(args, "resample", False)
+    need_tempres = getattr(args, "resample", True)
     tempres_floats: List[float] = []
     try:
         if need_tempres:
@@ -68,8 +68,8 @@ def command_train(args: argparse.Namespace) -> None:
 
     print(f"Loaded {len(contours)} contours")
 
-    if getattr(args, "resample", False):
-        sample_interval = getattr(args, "sample_interval", 0.02)
+    if getattr(args, "resample", True):
+        sample_interval = getattr(args, "sample_interval", 0.01)
         contours = resample_contours(contours, tempres_floats, sample_interval)
         print(f"Resampled contours to {sample_interval}s interval")
 
@@ -88,6 +88,10 @@ def command_train(args: argparse.Namespace) -> None:
         warp_factor_level=args.warp_factor,
         random_seed=args.seed,
         verbose=not args.quiet,
+        recat_single_categories=args.recat_single_categories,
+        compare_warped=args.compare_warped,
+        deprioritize_lone_category_search=args.deprioritize_lone_category_search,
+        purge_empty_categories=args.purge_empty_categories,
     )
 
     # train
@@ -298,7 +302,10 @@ def create_parser() -> argparse.ArgumentParser:
         "--learning-rate", type=float, default=0.1, help="Learning rate (0-1, default: 0.1)"
     )
     train_parser.add_argument(
-        "--bias", type=float, default=0.0, help="Activation bias (0-1, default: 0.0)"
+        "--bias",
+        type=float,
+        default=1e-6,
+        help="Activation bias (0-1, default: 1e-6)",
     )
     train_parser.add_argument(
         "--max-categories", type=int, default=50, help="Maximum number of categories (default: 50)"
@@ -319,20 +326,29 @@ def create_parser() -> argparse.ArgumentParser:
         "--export-categories", action="store_true", help="Export category assignments to CSV"
     )
     train_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
-    train_parser.add_argument(
+    _resample_mx = train_parser.add_mutually_exclusive_group()
+    _resample_mx.add_argument(
         "--resample",
+        dest="resample",
         action="store_true",
-        help=(
-            "Resample contours to a uniform temporal resolution before training "
-            "(like MATLAB resample option)"
-        ),
+        help="Resample contours before training (default: on)",
     )
+    _resample_mx.add_argument(
+        "--no-resample",
+        dest="resample",
+        action="store_false",
+        help="Disable resampling",
+    )
+    train_parser.set_defaults(resample=True)
     train_parser.add_argument(
         "--sample-interval",
         type=float,
-        default=0.02,
+        default=0.01,
         metavar="SEC",
-        help="Target sampling interval in seconds when --resample (default: 0.02)",
+        help=(
+            "Target sampling interval in seconds when resampling is on "
+            "(default: 0.01)"
+        ),
     )
     train_parser.add_argument(
         "--tempres",
@@ -340,8 +356,8 @@ def create_parser() -> argparse.ArgumentParser:
         default=0.01,
         metavar="SEC",
         help=(
-            "Default temporal resolution (sec/point) for contours that do not provide it, "
-            "when --resample (default: 0.01)"
+            "Default temporal resolution (sec/point) for contours that do not provide it "
+            "when resampling is on (default: 0.01)"
         ),
     )
     train_parser.add_argument(
@@ -353,6 +369,42 @@ def create_parser() -> argparse.ArgumentParser:
             "Cap contour length to N points (downsample longer contours). "
             "Use to avoid huge memory use when contours are very long (e.g. 100k+ points). "
             "Example: 5000 keeps DTW matrices small."
+        ),
+    )
+    train_parser.add_argument(
+        "--recat-single-categories",
+        action="store_true",
+        help=(
+            "MATLAB recatSingleCats: after each iteration's sample loop, run "
+            "ARTwarp_Recat_Single_Cats (reassign lone-category contours when another "
+            "category resonates) (default: off)."
+        ),
+    )
+    train_parser.add_argument(
+        "--compare-warped",
+        action="store_true",
+        help=(
+            "MATLAB compareWarped: use compare-warped weight updates (ART_Update_Weights "
+            "compare_warped==1) and ARTwarp_Average_Weights after each iteration "
+            "(default: off)."
+        ),
+    )
+    train_parser.add_argument(
+        "--deprioritize-lone-category-search",
+        action="store_true",
+        help=(
+            "Experimental (PR delete_unused_categories): when a sample is the only "
+            "contour in its category, try other categories before its current one in the "
+            "resonance search order. Not in MATLAB stable v2.0 (default: off)."
+        ),
+    )
+    train_parser.add_argument(
+        "--purge-empty-categories",
+        action="store_true",
+        help=(
+            "Experimental (PR deleted_unused_categories): after each iteration, remove weight columns with zero "
+            "assigned contours and reindex category labels. Not in MATLAB stable v2.0 "
+            "(default: off)."
         ),
     )
 

--- a/src/artwarp/cli/main.py
+++ b/src/artwarp/cli/main.py
@@ -345,10 +345,7 @@ def create_parser() -> argparse.ArgumentParser:
         type=float,
         default=0.01,
         metavar="SEC",
-        help=(
-            "Target sampling interval in seconds when resampling is on "
-            "(default: 0.01)"
-        ),
+        help=("Target sampling interval in seconds when resampling is on " "(default: 0.01)"),
     )
     train_parser.add_argument(
         "--tempres",
@@ -402,8 +399,9 @@ def create_parser() -> argparse.ArgumentParser:
         "--purge-empty-categories",
         action="store_true",
         help=(
-            "Experimental (PR deleted_unused_categories): after each iteration, remove weight columns with zero "
-            "assigned contours and reindex category labels. Not in MATLAB stable v2.0 "
+            "Experimental (PR deleted_unused_categories): after each iteration, "
+            "remove weight columns with zero assigned contours and reindex category "
+            "labels. Not in MATLAB stable v2.0 "
             "(default: off)."
         ),
     )

--- a/src/artwarp/core/__init__.py
+++ b/src/artwarp/core/__init__.py
@@ -6,10 +6,12 @@
 from artwarp.core.art import activate_categories, calculate_match
 from artwarp.core.dtw import dynamic_time_warp, unwarp
 from artwarp.core.network import ARTwarp, TrainingResults
+from artwarp.core.weights import purge_empty_category_columns
 
 __all__ = [
     "ARTwarp",
     "TrainingResults",
+    "purge_empty_category_columns",
     "dynamic_time_warp",
     "unwarp",
     "activate_categories",

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -223,23 +223,17 @@ class ARTwarp:
             sample_order = np.random.permutation(num_samples)
             num_reclassifications = 0
 
-            # calculate the number of contours in each category
-            if iteration > 1:
-                # filter out nan
-                keep = ~np.isnan(categories)
-                num_per_cat = np.bincount(categories[keep].astype(np.int64))
-
             for sample_idx in sample_order:
                 old_category = categories[sample_idx]
                 current_contour = contours[sample_idx]
 
-                if iteration > 1:
-                    if np.isnan(old_category):
-                        num_in_old_category = 0
-                    else:
-                        num_in_old_category = num_per_cat[old_category.astype(np.int64)]
-                else:
+                
+                if np.isnan(old_category):
                     num_in_old_category = 0
+                else:
+                    # calculate the number of whistles in the category
+                    num_in_old_category = (categories == old_category).sum()
+
 
                 # activate categories (bottom-up)
                 if self.num_categories > 0:
@@ -259,13 +253,8 @@ class ARTwarp:
                 # if 1 contour category check every other category first
                 if num_in_old_category == 1:
                     # moves the previous category to the back
-                    sorted_indices_old = np.roll(sorted_indices, -1)
-                    
                     sorted_indices = sorted_indices[sorted_indices != old_category]
                     sorted_indices = np.append(sorted_indices, old_category).astype(np.int32)
-                    if (not all(sorted_indices == sorted_indices_old)):
-                        print(sorted_indices_old)
-                        print(sorted_indices)
 
                 for cat_rank in range(len(sorted_indices)):
 

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -26,6 +26,7 @@ from artwarp.core.weights import (
     get_weight_contour,
     initialize_weight_matrix,
     update_weights,
+    delete_category,
 )
 
 
@@ -222,9 +223,18 @@ class ARTwarp:
             sample_order = np.random.permutation(num_samples)
             num_reclassifications = 0
 
+            # CHANGE
+            # calculate the number of contours in each category
+            if iteration > 1:
+                num_per_cat = np.bincount(categories.astype(np.int64))
+
             for sample_idx in sample_order:
                 old_category = categories[sample_idx]
                 current_contour = contours[sample_idx]
+                if iteration > 1:
+                    num_in_old_category = num_per_cat[old_category.astype(np.int64)]       
+                else:
+                    num_in_old_category = 0         
 
                 # activate categories (bottom-up)
                 if self.num_categories > 0:
@@ -237,13 +247,22 @@ class ARTwarp:
                 else:
                     # no categories yet
                     sorted_indices = np.array([], dtype=np.int32)
-
-                # search for resonance
+                
                 resonance = False
                 max_match = 0.0
 
+
+                #CHANGE
+                # if it is the only contour in the category check every other category before choosing its previous category
+                if num_in_old_category == 1:
+                    # moves the first element to the back
+                    sorted_indices = np.roll(sorted_indices, -1)
+                    
+
                 for cat_rank in range(len(sorted_indices)):
+
                     cat_idx = sorted_indices[cat_rank]
+                    #print(cat_idx)
 
                     # weight contour + warp func
                     weight_contour = get_weight_contour(self.weight_matrix, cat_idx)
@@ -299,6 +318,32 @@ class ARTwarp:
             new_cats_this_round = self.num_categories - categories_at_iter_start
             pct_reclass = (num_reclassifications / num_samples * 100) if num_samples else 0
 
+            # CHANGE    
+            #calculate number of categories with 0 and 1 contours
+            num_per_cat = np.bincount(categories.astype(np.int64))
+            # print(f"Number of categories with no contours: {np.count_nonzero(num_per_cat == 0)}")
+            # print(f"Number of catgeories with 1 contour: {np.count_nonzero(num_per_cat == 1)}")
+
+            
+            # delete all categories with no contours
+            num_cat_deleted = 0
+            i = 0
+            # print(num_per_cat)
+            # print(categories)
+            while i < len(num_per_cat):
+                
+                if num_per_cat[i] == 0:
+                    num_cat_deleted += 1
+                    self.weight_matrix = delete_category(i, self.weight_matrix)
+                    
+                    # shift all other cat_idx by 1 so they are still correct
+                    categories = np.where(categories > i, categories-1, categories)
+                    self.num_categories -= 1
+                    num_per_cat = np.delete(num_per_cat, i)
+                else:
+                    # only move forward if a category isn't deleted as we are iterating over an array we are modifying
+                    i += 1
+
             if self.verbose:
                 color = _green if num_reclassifications == 0 else _red
                 reclass_str = (
@@ -309,6 +354,7 @@ class ARTwarp:
                     f"  {color}iter {iteration:3d}{_reset}  │  "
                     f"categories {self.num_categories:3d}  "
                     f"(+{new_cats_this_round:2d} this round)  │  {reclass_str}"
+                    f"  |  deleted {num_cat_deleted:2d} categories this round"
                 )
             categories_at_iter_start = self.num_categories
 

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -258,8 +258,14 @@ class ARTwarp:
 
                 # if 1 contour category check every other category first
                 if num_in_old_category == 1:
-                    # moves the first element to the back
-                    sorted_indices = np.roll(sorted_indices, -1)
+                    # moves the previous category to the back
+                    sorted_indices_old = np.roll(sorted_indices, -1)
+                    
+                    sorted_indices = sorted_indices[sorted_indices != old_category]
+                    sorted_indices = np.append(sorted_indices, old_category).astype(np.int32)
+                    if (not all(sorted_indices == sorted_indices_old)):
+                        print(sorted_indices_old)
+                        print(sorted_indices)
 
                 for cat_rank in range(len(sorted_indices)):
 

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -104,11 +104,14 @@ class ARTwarp:
             Default False matches MATLAB with ``compareWarped`` off.
         deprioritize_lone_category_search: If True, when the current sample is the **only**
             contour assigned to its category, try **other** categories in activation order
-            **before** its current category (experimental behaviour from PR deleted_unused_categories
-            ``delete_unused_categories`` / ``f671e5a``). **Not** in MATLAB ``stable``. Default False.
+            **before** its current category (experimental behaviour from PR
+            deleted_unused_categories
+            ``delete_unused_categories`` / ``f671e5a``). **Not** in MATLAB ``stable``.
+            Default False.
         purge_empty_categories: If True, after each iteration (after optional recat /
             ``compare_warped``), remove weight columns with **zero** assigned contours and
-            reindex assignments (same PR deleted_unused_categories cleanup). **Not** in MATLAB ``stable``. Default False.
+            reindex assignments (same PR deleted_unused_categories cleanup). **Not** in
+            MATLAB ``stable``. Default False.
 
     Example:
         >>> network = ARTwarp(vigilance=85.0, learning_rate=0.1)
@@ -233,10 +236,8 @@ class ARTwarp:
             print(f"Warp factor:     {self.warp_factor_level}")
             print(f"Recat single cats: {self.recat_single_categories}")
             print(f"Compare warped:    {self.compare_warped}")
-            print(
-                f"Deprioritize lone: {self.deprioritize_lone_category_search}")
-            print(
-                f"Purge empty cats:  {self.purge_empty_categories}")
+            print(f"Deprioritize lone: {self.deprioritize_lone_category_search}")
+            print(f"Purge empty cats:  {self.purge_empty_categories}")
             if self._random_seed is not None:
                 print(f"Random seed:     {self._random_seed}")
             print()
@@ -276,7 +277,8 @@ class ARTwarp:
                 resonance = False
                 max_match = 0.0
 
-                # PR deleted_unused_categories (martion2007): if lone in category, try other prototypes first
+                # PR deleted_unused_categories (martion2007): if lone in category
+                # try other prototypes first
                 if (
                     self.deprioritize_lone_category_search
                     and num_in_old_category == 1
@@ -348,9 +350,7 @@ class ARTwarp:
                 )
 
             if self.compare_warped:
-                contour_lengths = np.array(
-                    [len(c) for c in contours], dtype=np.int64
-                )
+                contour_lengths = np.array([len(c) for c in contours], dtype=np.int64)
                 self.weight_matrix = average_weights(
                     self.weight_matrix, contour_lengths, categories
                 )

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -227,13 +227,11 @@ class ARTwarp:
                 old_category = categories[sample_idx]
                 current_contour = contours[sample_idx]
 
-                
                 if np.isnan(old_category):
                     num_in_old_category = 0
                 else:
                     # calculate the number of whistles in the category
                     num_in_old_category = (categories == old_category).sum()
-
 
                 # activate categories (bottom-up)
                 if self.num_categories > 0:

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -223,7 +223,6 @@ class ARTwarp:
             sample_order = np.random.permutation(num_samples)
             num_reclassifications = 0
 
-            # CHANGE
             # calculate the number of contours in each category
             if iteration > 1:
                 num_per_cat = np.bincount(categories.astype(np.int64))
@@ -251,8 +250,6 @@ class ARTwarp:
                 resonance = False
                 max_match = 0.0
 
-
-                #CHANGE
                 # if it is the only contour in the category check every other category before choosing its previous category
                 if num_in_old_category == 1:
                     # moves the first element to the back
@@ -262,7 +259,6 @@ class ARTwarp:
                 for cat_rank in range(len(sorted_indices)):
 
                     cat_idx = sorted_indices[cat_rank]
-                    #print(cat_idx)
 
                     # weight contour + warp func
                     weight_contour = get_weight_contour(self.weight_matrix, cat_idx)

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -494,7 +494,7 @@ class ARTwarp:
         num_samples = len(contours)
         num_categories = weight.shape[1]
 
-        lone_mask = np.ones(num_samples, dtype=bool)
+        lone_mask: NDArray[np.bool_] = np.ones(num_samples, dtype=np.bool_)
         lone_mask[np.isnan(categories)] = False
         for cat in range(num_categories):
             cat_mask = categories == cat

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -10,7 +10,7 @@ categorization algorithm, combining DTW and ART components.
 import sys
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -23,9 +23,11 @@ from artwarp.core.art import (
 )
 from artwarp.core.weights import (
     add_new_category,
-    delete_category,
+    average_weights,
+    delete_category_reindex_assignments,
     get_weight_contour,
     initialize_weight_matrix,
+    purge_empty_category_columns,
     update_weights,
 )
 
@@ -94,6 +96,19 @@ class ARTwarp:
         warp_factor_level: Maximum DTW warping factor (default: 3)
         random_seed: Random seed for reproducibility (optional)
         verbose: Whether to print progress information
+        recat_single_categories: If True, run MATLAB ``ARTwarp_Recat_Single_Cats`` after each
+            iteration's sample loop (reassign lone-category contours when another category
+            resonates). Default False matches MATLAB with ``recatSingleCats`` off.
+        compare_warped: If True, use MATLAB ``compareWarped == 1`` weight updates (fixed
+            reference length) and, after each iteration, ``ARTwarp_Average_Weights``.
+            Default False matches MATLAB with ``compareWarped`` off.
+        deprioritize_lone_category_search: If True, when the current sample is the **only**
+            contour assigned to its category, try **other** categories in activation order
+            **before** its current category (experimental behaviour from PR deleted_unused_categories
+            ``delete_unused_categories`` / ``f671e5a``). **Not** in MATLAB ``stable``. Default False.
+        purge_empty_categories: If True, after each iteration (after optional recat /
+            ``compare_warped``), remove weight columns with **zero** assigned contours and
+            reindex assignments (same PR deleted_unused_categories cleanup). **Not** in MATLAB ``stable``. Default False.
 
     Example:
         >>> network = ARTwarp(vigilance=85.0, learning_rate=0.1)
@@ -111,6 +126,10 @@ class ARTwarp:
         warp_factor_level: int = 3,
         random_seed: Optional[int] = None,
         verbose: bool = True,
+        recat_single_categories: bool = False,
+        compare_warped: bool = False,
+        deprioritize_lone_category_search: bool = False,
+        purge_empty_categories: bool = False,
     ):
         # validate params
         if not 1 <= vigilance <= 99:
@@ -134,6 +153,10 @@ class ARTwarp:
         self.warp_factor_level = warp_factor_level
         self.verbose = verbose
         self._random_seed = random_seed
+        self.recat_single_categories = recat_single_categories
+        self.compare_warped = compare_warped
+        self.deprioritize_lone_category_search = deprioritize_lone_category_search
+        self.purge_empty_categories = purge_empty_categories
 
         # optional random seed
         if random_seed is not None:
@@ -165,7 +188,7 @@ class ARTwarp:
                     1. Activate all categories (bottom-up)
                     2. Sort categories by activation
                     3. Search for resonance:
-                        - Calculate match with top category
+                        - Calculate match with sorted categories in order
                         - If match > vigilance: assign and update weights
                         - Else: try next category
                         - If all fail: create new category (if allowed)
@@ -208,6 +231,12 @@ class ARTwarp:
             print(f"Max categories:  {self.max_categories}")
             print(f"Max iterations:  {self.max_iterations}")
             print(f"Warp factor:     {self.warp_factor_level}")
+            print(f"Recat single cats: {self.recat_single_categories}")
+            print(f"Compare warped:    {self.compare_warped}")
+            print(
+                f"Deprioritize lone: {self.deprioritize_lone_category_search}")
+            print(
+                f"Purge empty cats:  {self.purge_empty_categories}")
             if self._random_seed is not None:
                 print(f"Random seed:     {self._random_seed}")
             print()
@@ -230,8 +259,7 @@ class ARTwarp:
                 if np.isnan(old_category):
                     num_in_old_category = 0
                 else:
-                    # calculate the number of whistles in the category
-                    num_in_old_category = (categories == old_category).sum()
+                    num_in_old_category = int((categories == old_category).sum())
 
                 # activate categories (bottom-up)
                 if self.num_categories > 0:
@@ -248,11 +276,16 @@ class ARTwarp:
                 resonance = False
                 max_match = 0.0
 
-                # if 1 contour category check every other category first
-                if num_in_old_category == 1:
-                    # moves the previous category to the back
-                    sorted_indices = sorted_indices[sorted_indices != old_category]
-                    sorted_indices = np.append(sorted_indices, old_category).astype(np.int32)
+                # PR deleted_unused_categories (martion2007): if lone in category, try other prototypes first
+                if (
+                    self.deprioritize_lone_category_search
+                    and num_in_old_category == 1
+                    and sorted_indices.size > 0
+                ):
+                    oc = int(old_category)
+                    if 0 <= oc < self.num_categories and np.any(sorted_indices == oc):
+                        others = sorted_indices[sorted_indices != oc]
+                        sorted_indices = np.append(others, oc).astype(np.int32)
 
                 for cat_rank in range(len(sorted_indices)):
 
@@ -281,6 +314,7 @@ class ARTwarp:
                             cat_idx,
                             self.learning_rate,
                             warp_func,
+                            compare_warped=self.compare_warped,
                         )
                         categories[sample_idx] = cat_idx
                         matches[sample_idx] = match
@@ -307,32 +341,30 @@ class ARTwarp:
                     if not (np.isnan(old_category) and np.isnan(categories[sample_idx])):
                         num_reclassifications += 1
 
-            # record iteration
+            # MATLAB ARTwarp_Run_Categorisation.m: optional post-iteration recat, then average
+            if self.recat_single_categories:
+                categories, matches, self.weight_matrix, self.num_categories = (
+                    self._recat_single_categories(contours, categories, matches)
+                )
+
+            if self.compare_warped:
+                contour_lengths = np.array(
+                    [len(c) for c in contours], dtype=np.int64
+                )
+                self.weight_matrix = average_weights(
+                    self.weight_matrix, contour_lengths, categories
+                )
+
+            num_purged_empty = 0
+            if self.purge_empty_categories and self.weight_matrix is not None:
+                self.weight_matrix, categories, num_purged_empty = purge_empty_category_columns(
+                    self.weight_matrix, categories
+                )
+                self.num_categories = int(self.weight_matrix.shape[1])
+
             iteration_history.append((iteration, num_reclassifications))
             new_cats_this_round = self.num_categories - categories_at_iter_start
             pct_reclass = (num_reclassifications / num_samples * 100) if num_samples else 0
-
-            # calculate number of categories with 0 and 1 contours
-            # filter out nan values
-            keep = ~np.isnan(categories)
-            num_per_cat = np.bincount(categories[keep].astype(np.int64))
-
-            # delete all categories with no contours
-            num_cat_deleted = 0
-            i = 0
-
-            while i < len(num_per_cat):
-                if num_per_cat[i] == 0:
-                    num_cat_deleted += 1
-                    self.weight_matrix = delete_category(i, self.weight_matrix)
-
-                    # shift all other cat_idx by 1 so they are still correct
-                    categories = np.where(categories > i, categories - 1, categories)
-                    self.num_categories -= 1
-                    num_per_cat = np.delete(num_per_cat, i)
-                else:
-                    # only move forward if a category isn't deleted
-                    i += 1
 
             if self.verbose:
                 color = _green if num_reclassifications == 0 else _red
@@ -340,11 +372,16 @@ class ARTwarp:
                     f"reclassified {num_reclassifications:4d} / {num_samples} "
                     f"({pct_reclass:5.1f}%){_reset}"
                 )
+                purge_str = (
+                    f"  │  purged {num_purged_empty:2d} empty categories"
+                    if self.purge_empty_categories
+                    else ""
+                )
                 print(
                     f"  {color}iter {iteration:3d}{_reset}  │  "
                     f"categories {self.num_categories:3d}  "
                     f"(+{new_cats_this_round:2d} this round)  │  {reclass_str}"
-                    f"  |  deleted {num_cat_deleted:2d} categories this round"
+                    f"{purge_str}"
                 )
             categories_at_iter_start = self.num_categories
 
@@ -438,3 +475,84 @@ class ARTwarp:
                 matches[idx] = 0.0
 
         return categories, matches
+
+    def _recat_single_categories(
+        self,
+        contours: List[NDArray[np.float64]],
+        categories: NDArray[np.float64],
+        matches: NDArray[np.float64],
+    ) -> Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64], int]:
+        """
+        MATLAB ARTwarp_Recat_Single_Cats.m — reassign lone contours when a better match exists.
+
+        Operates on the same data layout as the MATLAB ``categories`` / ``matches`` vectors
+        (0-based category indices; NaN for unassigned).
+        """
+        weight = self.weight_matrix
+        if weight is None:
+            raise RuntimeError("Weight matrix must be initialized before recat")
+        num_samples = len(contours)
+        num_categories = weight.shape[1]
+
+        lone_mask = np.ones(num_samples, dtype=bool)
+        lone_mask[np.isnan(categories)] = False
+        for cat in range(num_categories):
+            cat_mask = categories == cat
+            if np.sum(cat_mask) != 1:
+                lone_mask[cat_mask] = False
+        lone_indices = np.flatnonzero(lone_mask)
+        num_lone = int(lone_indices.size)
+        single_cats_moved = 0
+
+        if num_lone == 0:
+            return categories, matches, weight, num_categories
+
+        order = np.argsort(np.random.randn(num_lone))
+        cats = categories.copy()
+        mats = matches.copy()
+
+        for step in range(num_lone):
+            k = int(order[step])
+            idx = int(lone_indices[k])
+            current_data = contours[idx]
+            old_category = int(cats[idx])
+
+            activations, warp_functions = activate_categories(
+                current_data, weight, self.bias, self.warp_factor_level
+            )
+            activations = activations.astype(np.float64, copy=True)
+            activations[old_category] = np.nan
+            if np.all(np.isnan(activations)):
+                continue
+            best_match_idx = int(np.nanargmax(activations))
+            warp_func = warp_functions[best_match_idx]
+            weight_contour = get_weight_contour(weight, best_match_idx)
+            if len(warp_func) == 0:
+                continue
+            warped_input = current_data[warp_func]
+            match_val = float(calculate_match(warped_input, weight_contour))
+
+            if check_resonance(match_val, self.vigilance):
+                weight = update_weights(
+                    current_data,
+                    weight,
+                    best_match_idx,
+                    self.learning_rate,
+                    warp_func,
+                    compare_warped=self.compare_warped,
+                )
+                old_cat_mask = cats == old_category
+                mats[old_cat_mask] = match_val
+                cats[old_cat_mask] = best_match_idx
+                weight, cats = delete_category_reindex_assignments(old_category, weight, cats)
+                num_categories = weight.shape[1]
+                single_cats_moved += 1
+
+        if self.verbose:
+            print(
+                f"Number of single-contour-category contours reclassified "
+                f"{single_cats_moved:2d}"
+            )
+
+        self.weight_matrix = weight
+        return cats, mats, weight, num_categories

--- a/src/artwarp/core/network.py
+++ b/src/artwarp/core/network.py
@@ -23,10 +23,10 @@ from artwarp.core.art import (
 )
 from artwarp.core.weights import (
     add_new_category,
+    delete_category,
     get_weight_contour,
     initialize_weight_matrix,
     update_weights,
-    delete_category,
 )
 
 
@@ -225,15 +225,21 @@ class ARTwarp:
 
             # calculate the number of contours in each category
             if iteration > 1:
-                num_per_cat = np.bincount(categories.astype(np.int64))
+                # filter out nan
+                keep = ~np.isnan(categories)
+                num_per_cat = np.bincount(categories[keep].astype(np.int64))
 
             for sample_idx in sample_order:
                 old_category = categories[sample_idx]
                 current_contour = contours[sample_idx]
+
                 if iteration > 1:
-                    num_in_old_category = num_per_cat[old_category.astype(np.int64)]       
+                    if np.isnan(old_category):
+                        num_in_old_category = 0
+                    else:
+                        num_in_old_category = num_per_cat[old_category.astype(np.int64)]
                 else:
-                    num_in_old_category = 0         
+                    num_in_old_category = 0
 
                 # activate categories (bottom-up)
                 if self.num_categories > 0:
@@ -246,15 +252,14 @@ class ARTwarp:
                 else:
                     # no categories yet
                     sorted_indices = np.array([], dtype=np.int32)
-                
+
                 resonance = False
                 max_match = 0.0
 
-                # if it is the only contour in the category check every other category before choosing its previous category
+                # if 1 contour category check every other category first
                 if num_in_old_category == 1:
                     # moves the first element to the back
                     sorted_indices = np.roll(sorted_indices, -1)
-                    
 
                 for cat_rank in range(len(sorted_indices)):
 
@@ -314,30 +319,26 @@ class ARTwarp:
             new_cats_this_round = self.num_categories - categories_at_iter_start
             pct_reclass = (num_reclassifications / num_samples * 100) if num_samples else 0
 
-            # CHANGE    
-            #calculate number of categories with 0 and 1 contours
-            num_per_cat = np.bincount(categories.astype(np.int64))
-            # print(f"Number of categories with no contours: {np.count_nonzero(num_per_cat == 0)}")
-            # print(f"Number of catgeories with 1 contour: {np.count_nonzero(num_per_cat == 1)}")
+            # calculate number of categories with 0 and 1 contours
+            # filter out nan values
+            keep = ~np.isnan(categories)
+            num_per_cat = np.bincount(categories[keep].astype(np.int64))
 
-            
             # delete all categories with no contours
             num_cat_deleted = 0
             i = 0
-            # print(num_per_cat)
-            # print(categories)
+
             while i < len(num_per_cat):
-                
                 if num_per_cat[i] == 0:
                     num_cat_deleted += 1
                     self.weight_matrix = delete_category(i, self.weight_matrix)
-                    
+
                     # shift all other cat_idx by 1 so they are still correct
-                    categories = np.where(categories > i, categories-1, categories)
+                    categories = np.where(categories > i, categories - 1, categories)
                     self.num_categories -= 1
                     num_per_cat = np.delete(num_per_cat, i)
                 else:
-                    # only move forward if a category isn't deleted as we are iterating over an array we are modifying
+                    # only move forward if a category isn't deleted
                     i += 1
 
             if self.verbose:

--- a/src/artwarp/core/weights.py
+++ b/src/artwarp/core/weights.py
@@ -62,9 +62,9 @@ def add_new_category(
         # append to existing
         return np.column_stack([weight_matrix, new_category])
 
-def delete_category(cat_idx : int, weight_matrix: NDArray[np.float64]) -> NDArray[np.float64]:
-    return np.delete(weight_matrix, cat_idx, axis=1)
 
+def delete_category(cat_idx: int, weight_matrix: NDArray[np.float64]) -> NDArray[np.float64]:
+    return np.delete(weight_matrix, cat_idx, axis=1)
 
 
 def update_weights(

--- a/src/artwarp/core/weights.py
+++ b/src/artwarp/core/weights.py
@@ -62,6 +62,10 @@ def add_new_category(
         # append to existing
         return np.column_stack([weight_matrix, new_category])
 
+def delete_category(cat_idx : int, weight_matrix: NDArray[np.float64]) -> NDArray[np.float64]:
+    return np.delete(weight_matrix, cat_idx, axis=1)
+
+
 
 def update_weights(
     input_contour: NDArray[np.float64],

--- a/src/artwarp/core/weights.py
+++ b/src/artwarp/core/weights.py
@@ -150,6 +150,7 @@ def purge_empty_category_columns(
     num_deleted = 0
 
     valid = ~np.isnan(c)
+    counts: NDArray[np.int64]
     if not np.any(valid):
         counts = np.zeros(n_col, dtype=np.int64)
     else:

--- a/src/artwarp/core/weights.py
+++ b/src/artwarp/core/weights.py
@@ -10,6 +10,8 @@ This module handles:
 @author: Pedro Gronda Garrigues
 """
 
+from typing import Tuple
+
 import numpy as np
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
@@ -63,8 +65,162 @@ def add_new_category(
         return np.column_stack([weight_matrix, new_category])
 
 
-def delete_category(cat_idx: int, weight_matrix: NDArray[np.float64]) -> NDArray[np.float64]:
-    return np.delete(weight_matrix, cat_idx, axis=1)
+def delete_category(
+    category_index: int, weight_matrix: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """
+    Delete a category column from the weight matrix.
+
+    Args:
+        category_index: 0-based category index to delete
+        weight_matrix: Current weight matrix, shape (max_features, num_categories)
+
+    Returns:
+        Updated weight matrix with shape (max_features, num_categories - 1)
+    """
+    if weight_matrix.shape[1] == 0:
+        raise ValueError("Cannot delete category from an empty weight matrix")
+    if category_index < 0 or category_index >= weight_matrix.shape[1]:
+        raise IndexError(
+            f"Category index {category_index} out of bounds for "
+            f"{weight_matrix.shape[1]} categories"
+        )
+    return np.delete(weight_matrix, category_index, axis=1)
+
+
+def delete_category_reindex_assignments(
+    category_index: int,
+    weight_matrix: NDArray[np.float64],
+    categories: NDArray[np.float64],
+) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """
+    Remove one category column and shift category indices (MATLAB ARTwarp_Delete_Category.m).
+
+    Contour assignments use 0-based category indices. NaN assignments are unchanged.
+    """
+    updated_weight = delete_category(category_index, weight_matrix)
+    updated_categories = categories.copy()
+    for i in range(len(categories)):
+        cat = categories[i]
+        if np.isnan(cat):
+            continue
+        ci = int(cat)
+        if ci == category_index:
+            raise ValueError(
+                "Attempted to delete a non-empty category: a category was found which "
+                "matches the deletion reference"
+            )
+        if ci > category_index:
+            updated_categories[i] = ci - 1
+    return updated_weight, updated_categories
+
+
+def purge_empty_category_columns(
+    weight_matrix: NDArray[np.float64],
+    categories: NDArray[np.float64],
+) -> Tuple[NDArray[np.float64], NDArray[np.float64], int]:
+    """
+    Remove weight columns that have no assigned contours (orphan prototypes).
+
+    This matches the post-iteration cleanup from experimental PR
+    (``martion2007/delete_unused_categories``, merged as ``f671e5a``): after
+    reassignments, some category indices may have zero samples while the column
+    still exists. Those columns are deleted and remaining category indices are
+    shifted down by one per removal, in ascending index order (same loop
+    structure as the reference implementation).
+
+    This is **not** part of MATLAB ``stable`` ``ARTwarp_Run_Categorisation.m``.
+    It is optional and defaults off in ``ARTwarp``.
+
+    Args:
+        weight_matrix: Shape ``(max_features, num_categories)``.
+        categories: Per-sample category indices; NaN = unassigned.
+
+    Returns:
+        ``(updated_weight_matrix, updated_categories, num_deleted)``.
+
+    Raises:
+        ValueError: If any finite category index is outside
+            ``[0, num_categories-1]``.
+    """
+    n_col = int(weight_matrix.shape[1])
+    if n_col == 0:
+        return weight_matrix, categories, 0
+
+    w = weight_matrix
+    c = categories.copy()
+    num_deleted = 0
+
+    valid = ~np.isnan(c)
+    if not np.any(valid):
+        counts = np.zeros(n_col, dtype=np.int64)
+    else:
+        cc = c[valid].astype(np.int64, copy=False)
+        if np.any(cc < 0) or np.any(cc >= n_col):
+            raise ValueError(
+                "purge_empty_category_columns: category index out of range "
+                f"for weight_matrix with {n_col} columns"
+            )
+        bc = np.bincount(cc, minlength=n_col)
+        counts = np.asarray(bc[:n_col], dtype=np.int64)
+
+    i = 0
+    while i < n_col:
+        if counts[i] == 0:
+            w = delete_category(i, w)
+            c = np.where(c > i, c - 1, c)
+            num_deleted += 1
+            n_col = int(w.shape[1])
+            valid = ~np.isnan(c)
+            if n_col == 0:
+                counts = np.zeros(0, dtype=np.int64)
+            elif not np.any(valid):
+                counts = np.zeros(n_col, dtype=np.int64)
+            else:
+                cc = c[valid].astype(np.int64, copy=False)
+                if np.any(cc < 0) or np.any(cc >= n_col):
+                    raise ValueError(
+                        "purge_empty_category_columns: inconsistent state after delete"
+                    )
+                bc = np.bincount(cc, minlength=n_col)
+                counts = np.asarray(bc[:n_col], dtype=np.int64)
+        else:
+            i += 1
+
+    return w, c, num_deleted
+
+
+def average_weights(
+    weight_matrix: NDArray[np.float64],
+    contour_lengths: NDArray[np.int64],
+    categories: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """
+    Resample each category weight to the mean length of contours in that category.
+
+    Matches MATLAB ARTwarp_Average_Weights.m: categories with no assigned contours
+    (empty ``contourLengths``) are left unchanged.
+    """
+    num_features, num_categories = weight_matrix.shape
+    weight = weight_matrix.copy()
+    for cat in range(num_categories):
+        mask = (categories == cat) & ~np.isnan(categories)
+        cl = contour_lengths[mask]
+        if cl.size == 0:
+            continue
+        col = weight[:, cat]
+        i = col[col > 0]
+        weight_length = len(i)
+        if weight_length == 0:
+            continue
+        new_length = int(np.round(np.mean(cl)))
+        new_length = max(1, new_length)
+        x_old = np.arange(1, weight_length + 1, dtype=np.float64)
+        x_new = np.linspace(1, weight_length, new_length)
+        new_weight = np.interp(x_new, x_old, i.astype(np.float64, copy=False))
+        weight[:, cat] = np.nan
+        weight[:new_length, cat] = new_weight
+    return weight
 
 
 def update_weights(
@@ -73,6 +229,7 @@ def update_weights(
     category_index: int,
     learning_rate: float,
     warp_function: NDArray[np.int32],
+    compare_warped: bool = False,
 ) -> NDArray[np.float64]:
     """
     Update weight matrix for a category after successful match.
@@ -89,6 +246,9 @@ def update_weights(
             Higher values mean faster adaptation to new inputs
         warp_function: Warping function mapping weight to input, shape (m,)
             where m is the length of the weight vector
+        compare_warped: If False (default), match MATLAB ``compare_warped == 0``: learn
+            with length adaptation and unwarping. If True, match ``compare_warped == 1``:
+            keep reference length equal to the current weight length (no unwarp pass).
 
     Returns:
         Updated weight matrix with same shape as input
@@ -97,12 +257,12 @@ def update_weights(
         1. Extract current weight vector (remove NaN padding)
         2. Warp input contour to match weight length
         3. Update weight content: new_weight = old_weight + lr * (warped_input - old_weight)
-        4. Calculate new length: new_length = old_length + lr * (input_length - old_length)
-        5. Unwarp and interpolate to new length
+        4. If compare_warped is False: new length and unwarp interpolation (MATLAB branch)
+        5. If compare_warped is True: new_length = weight_length (MATLAB branch)
         6. Update weight matrix
 
     Note:
-        This implements the MATLAB ART_Update_Weights.m function.
+        This implements the MATLAB ART_Update_Weights.m function (ARTwarp_Update_Weights.m).
     """
     # extract current weight vector (MATLAB: find(weight(:,categoryNumber) > 0))
     weight_vector = weight_matrix[:, category_index]
@@ -124,38 +284,46 @@ def update_weights(
     # update weight with learning rate
     new_weight = current_weight + learning_rate * (warped_input - current_weight)
 
-    # new length => adapt toward input length
-    new_length = int(round(weight_length + learning_rate * (input_length - weight_length)))
-    new_length = max(1, new_length)  # at least 1
-
-    # unwarp function
-    unwarp_function = unwarp(warp_function)
-
-    # interpolate unwarp to new length
-    if len(unwarp_function) > 1:
-        old_indices = np.arange(len(unwarp_function))
-        new_indices = np.linspace(0, len(unwarp_function) - 1, new_length)
-
-        # interpolate unwarp
-        f_unwarp = interp1d(old_indices, unwarp_function, kind="linear", fill_value="extrapolate")
-        interpolated_unwarp = f_unwarp(new_indices)
-
-        # adjust unwarp with learning rate
-        weight_old_indices = np.linspace(0, weight_length - 1, new_length)
-        adjusted_unwarp = (
-            weight_old_indices - (weight_old_indices - interpolated_unwarp) * learning_rate
-        )
-        adjusted_unwarp = np.clip(adjusted_unwarp, 0, weight_length - 1)
+    if compare_warped:
+        new_length = weight_length
+        final_weight = new_weight
     else:
-        adjusted_unwarp = np.zeros(new_length)
+        # new length => adapt toward input length
+        new_length = int(round(weight_length + learning_rate * (input_length - weight_length)))
+        new_length = max(1, new_length)  # at least 1
 
-    # interpolate new weight to new length (adjusted unwarp)
-    if len(new_weight) > 1:
-        old_weight_indices = np.arange(len(new_weight))
-        f_weight = interp1d(old_weight_indices, new_weight, kind="linear", fill_value="extrapolate")
-        final_weight = f_weight(adjusted_unwarp)
-    else:
-        final_weight = np.full(new_length, new_weight[0])
+        # unwarp function
+        unwarp_function = unwarp(warp_function)
+
+        # interpolate unwarp to new length
+        if len(unwarp_function) > 1:
+            old_indices = np.arange(len(unwarp_function))
+            new_indices = np.linspace(0, len(unwarp_function) - 1, new_length)
+
+            # interpolate unwarp
+            f_unwarp = interp1d(
+                old_indices, unwarp_function, kind="linear", fill_value="extrapolate"
+            )
+            interpolated_unwarp = f_unwarp(new_indices)
+
+            # adjust unwarp with learning rate
+            weight_old_indices = np.linspace(0, weight_length - 1, new_length)
+            adjusted_unwarp = (
+                weight_old_indices - (weight_old_indices - interpolated_unwarp) * learning_rate
+            )
+            adjusted_unwarp = np.clip(adjusted_unwarp, 0, weight_length - 1)
+        else:
+            adjusted_unwarp = np.zeros(new_length)
+
+        # interpolate new weight to new length (adjusted unwarp)
+        if len(new_weight) > 1:
+            old_weight_indices = np.arange(len(new_weight))
+            f_weight = interp1d(
+                old_weight_indices, new_weight, kind="linear", fill_value="extrapolate"
+            )
+            final_weight = f_weight(adjusted_unwarp)
+        else:
+            final_weight = np.full(new_length, new_weight[0])
 
     # update weight matrix
     updated_matrix = weight_matrix.copy()

--- a/src/artwarp/core/weights.py
+++ b/src/artwarp/core/weights.py
@@ -65,9 +65,7 @@ def add_new_category(
         return np.column_stack([weight_matrix, new_category])
 
 
-def delete_category(
-    category_index: int, weight_matrix: NDArray[np.float64]
-) -> NDArray[np.float64]:
+def delete_category(category_index: int, weight_matrix: NDArray[np.float64]) -> NDArray[np.float64]:
     """
     Delete a category column from the weight matrix.
 

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -26,6 +26,10 @@ class TestARTwarpInitialization:
         assert network.max_categories == 100
         assert network.max_iterations == 50
         assert network.warp_factor_level == 3
+        assert network.recat_single_categories is False
+        assert network.compare_warped is False
+        assert network.deprioritize_lone_category_search is False
+        assert network.purge_empty_categories is False
 
     def test_custom_parameters(self):
         """Test network with custom parameters."""
@@ -200,6 +204,41 @@ class TestARTwarpTraining:
         assert isinstance(results.converged, bool)
         assert len(results.iteration_history) > 0
         assert results.training_time >= 0
+
+    def test_pr10_flags_training_smoke(self):
+        """Marco's PR optional extensions complete fit without error."""
+        contours = [
+            np.array([100.0, 200.0, 300.0]),
+            np.array([105.0, 205.0, 305.0]),
+            np.array([500.0, 600.0, 700.0]),
+        ]
+        net = ARTwarp(
+            vigilance=85.0,
+            verbose=False,
+            random_seed=42,
+            deprioritize_lone_category_search=True,
+            purge_empty_categories=True,
+        )
+        results = net.fit(contours)
+        assert results.num_categories >= 1
+        assert results.weight_matrix.shape[1] == results.num_categories
+
+    def test_purge_empty_verbose_shows_purged_count(self, capsys):
+        """When purge_empty_categories is on, iteration log includes purged count."""
+        contours = [
+            np.array([100.0, 200.0, 300.0]),
+            np.array([105.0, 205.0, 305.0]),
+        ]
+        net = ARTwarp(
+            vigilance=85.0,
+            verbose=True,
+            random_seed=0,
+            max_iterations=3,
+            purge_empty_categories=True,
+        )
+        net.fit(contours)
+        out = capsys.readouterr().out
+        assert "purged" in out
 
 
 class TestARTwarpPrediction:

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -304,3 +304,58 @@ class TestNumbaCheck:
         ):
             result = check_numba(offer_install=True, stream=stream)
         assert result is False
+
+
+class TestCLITrainMatlabFlags:
+    """CLI train passes recat / compare-warped into ARTwarp (MATLAB parity)."""
+
+    def test_recat_and_compare_warped_parse_to_true(self):
+        from artwarp.cli.main import create_parser
+
+        p = create_parser()
+        a = p.parse_args(
+            [
+                "train",
+                "-i",
+                "./contours",
+                "-o",
+                "results.pkl",
+                "--recat-single-categories",
+                "--compare-warped",
+            ]
+        )
+        assert a.command == "train"
+        assert a.recat_single_categories is True
+        assert a.compare_warped is True
+
+    def test_defaults_false(self):
+        from artwarp.cli.main import create_parser
+
+        p = create_parser()
+        a = p.parse_args(["train", "-i", "./c", "-o", "out.pkl"])
+        assert a.recat_single_categories is False
+        assert a.compare_warped is False
+        assert a.bias == 1e-6
+        assert a.resample is True
+        assert a.sample_interval == 0.01
+        assert a.deprioritize_lone_category_search is False
+        assert a.purge_empty_categories is False
+
+    def test_pr10_cli_flags_parse_to_true(self):
+        from artwarp.cli.main import create_parser
+
+        p = create_parser()
+        a = p.parse_args(
+            [
+                "train",
+                "-i",
+                "./c",
+                "-o",
+                "out.pkl",
+                "--deprioritize-lone-category-search",
+                "--purge-empty-categories",
+            ]
+        )
+        assert a.command == "train"
+        assert a.deprioritize_lone_category_search is True
+        assert a.purge_empty_categories is True

--- a/tests/unit/test_weights.py
+++ b/tests/unit/test_weights.py
@@ -1,0 +1,97 @@
+"""Unit tests for weight matrix helpers (MATLAB parity)."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from artwarp.core.weights import (
+    average_weights,
+    delete_category_reindex_assignments,
+    purge_empty_category_columns,
+    update_weights,
+)
+
+
+class TestAverageWeights:
+    """ARTwarp_Average_Weights.m — empty categories keep prior columns."""
+
+    def test_skips_categories_with_no_assigned_contours(self):
+        w = np.array(
+            [
+                [10.0, 20.0, 30.0],
+                [11.0, 21.0, 31.0],
+                [12.0, 22.0, 32.0],
+            ],
+            dtype=np.float64,
+        )
+        lengths = np.array([3, 3], dtype=np.int64)
+        cats = np.array([0.0, 1.0], dtype=np.float64)
+        out = average_weights(w, lengths, cats)
+        assert_allclose(out[:, 0], w[:, 0])
+        assert_allclose(out[:, 1], w[:, 1])
+        assert_allclose(out[:, 2], w[:, 2])
+
+    def test_resamples_to_mean_length(self):
+        w = np.zeros((5, 1), dtype=np.float64)
+        w[:3, 0] = [1.0, 2.0, 3.0]
+        lengths = np.array([5], dtype=np.int64)
+        cats = np.array([0.0])
+        out = average_weights(w, lengths, cats)
+        assert out.shape == w.shape
+        assert np.sum(np.isfinite(out[:, 0])) == 5
+
+
+class TestDeleteCategoryReindex:
+    """ARTwarp_Delete_Category.m"""
+
+    def test_reindexes_assignments(self):
+        w = np.ones((3, 3), dtype=np.float64)
+        # column 1 has no assignments; categories 0 and 2 are used
+        cats = np.array([0.0, 2.0, 0.0])
+        nw, nc = delete_category_reindex_assignments(1, w, cats)
+        assert nw.shape[1] == 2
+        assert_array_equal(nc, np.array([0.0, 1.0, 0.0]))
+
+    def test_rejects_delete_nonempty(self):
+        w = np.ones((2, 2), dtype=np.float64)
+        cats = np.array([0.0, 1.0])
+        with pytest.raises(ValueError, match="non-empty"):
+            delete_category_reindex_assignments(0, w, cats)
+
+
+class TestPurgeEmptyCategoryColumns:
+    """Marco's orphan-column purge (optional in ARTwarp.fit)."""
+
+    def test_removes_unreferenced_middle_column(self):
+        w = np.ones((2, 3), dtype=np.float64)
+        c = np.array([0.0, 0.0, 2.0], dtype=np.float64)
+        nw, nc, nd = purge_empty_category_columns(w, c)
+        assert nd == 1
+        assert nw.shape == (2, 2)
+        assert_array_equal(nc, np.array([0.0, 0.0, 1.0]))
+
+    def test_no_deletions_when_all_used(self):
+        w = np.ones((2, 2), dtype=np.float64)
+        c = np.array([0.0, 1.0], dtype=np.float64)
+        nw, nc, nd = purge_empty_category_columns(w, c)
+        assert nd == 0
+        assert_array_equal(nw, w)
+        assert_array_equal(nc, c)
+
+    def test_rejects_category_index_out_of_range(self):
+        w = np.ones((2, 2), dtype=np.float64)
+        c = np.array([0.0, 2.0], dtype=np.float64)
+        with pytest.raises(ValueError, match="out of range"):
+            purge_empty_category_columns(w, c)
+
+
+class TestUpdateWeightsCompareWarped:
+    """ART_Update_Weights compare_warped branch."""
+
+    def test_compare_warped_keeps_weight_length(self):
+        wm = np.full((5, 1), np.nan, dtype=np.float64)
+        wm[:3, 0] = [10.0, 20.0, 30.0]
+        inp = np.array([12.0, 22.0, 32.0, 40.0], dtype=np.float64)
+        warp = np.array([0, 1, 2], dtype=np.int32)
+        out = update_weights(inp, wm, 0, 0.5, warp, compare_warped=True)
+        assert np.sum(np.isfinite(out[:, 0])) == 3


### PR DESCRIPTION
Taking from **latest commit** (summary commit; squashed to not pollute feature branch!):

```
FEATURE: REMOVE-CATEGORY [EXPEREM+CLI] optional orphan purge; MATLAB train defaults

    - Train CLI / run.sh: bias 1e-6, resample on by default, --no-resample, sample-interval 0.01 (ARTwarp_cli_mode.m).

    - Optional Marco's PR (martion2007:delete_unused_categories): deprioritize_lone_category_search, purge_empty_categories, purge_empty_category_colu
mns; CLI flags + tests.

    - MATLAB v2.0 parity: --recat-single-categories / --compare-warped unchanged; docs sweep (API, ARCHITECTURE, QUICK_REFERENCE, INSTALLATION, README
, TEST_RESULTS, PROJECT_SUMMARY, VISUALIZATION).

    - examples/artwarp_demo.ipynb: §5/§5b + CLI §17; import purge_empty_category_columns.

    TODO: After merge to main, run full pytest on CI and spot-check pickle/report workflows with Marco's flags enabled.
```